### PR TITLE
Add custom tool framework

### DIFF
--- a/custom_components/mcp_assist/__init__.py
+++ b/custom_components/mcp_assist/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.components import conversation
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -17,6 +17,9 @@ from .const import (
     CONF_TECHNICAL_PROMPT,
     CONF_PROFILE_NAME,
     CONF_ENABLE_CUSTOM_TOOLS,
+    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+    CONF_ENABLE_CALCULATOR_TOOLS,
+    CONF_ENABLE_UNIT_CONVERSION_TOOLS,
     CONF_BRAVE_API_KEY,
     CONF_ALLOWED_IPS,
     CONF_SEARCH_PROVIDER,
@@ -24,6 +27,9 @@ from .const import (
     CONF_SERVER_TYPE,
     CONF_TIMEOUT,
     DEFAULT_ENABLE_CUSTOM_TOOLS,
+    DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+    DEFAULT_ENABLE_CALCULATOR_TOOLS,
+    DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
     DEFAULT_BRAVE_API_KEY,
     DEFAULT_ALLOWED_IPS,
     DEFAULT_SEARCH_PROVIDER,
@@ -34,6 +40,7 @@ from .const import (
     CONF_OPENCLAW_PORT,
     CONF_OPENCLAW_TOKEN,
     CONF_OPENCLAW_USE_SSL,
+    SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS,
 )
 from .mcp_server import MCPServer
 from .index_manager import IndexManager
@@ -59,6 +66,26 @@ async def _migrate_brave_search_tool_name(hass: HomeAssistant, entry: ConfigEntr
             "Profile '%s': Migrated Technical Instructions from 'brave_search' to 'search'",
             entry.data.get(CONF_PROFILE_NAME, "Default")
         )
+
+
+async def _async_handle_reload_external_custom_tools(call) -> dict:
+    """Reload manifest-based custom tool packages on the shared MCP server."""
+    hass = call.hass
+    server = hass.data.get(DOMAIN, {}).get("shared_mcp_server")
+    if server is None:
+        _LOGGER.warning("Cannot reload custom tools: shared MCP server is not running")
+        return {"success": False, "error": "Shared MCP server is not running"}
+
+    reload_external_custom_tools = getattr(
+        server,
+        "reload_external_custom_tools",
+        None,
+    )
+    if not callable(reload_external_custom_tools):
+        _LOGGER.warning("Cannot reload custom tools: server does not support reload")
+        return {"success": False, "error": "Custom tool reload is not available"}
+
+    return await reload_external_custom_tools()
 
 
 def get_system_entry(hass: HomeAssistant) -> ConfigEntry | None:
@@ -119,6 +146,27 @@ async def ensure_system_entry(hass: HomeAssistant) -> ConfigEntry:
                     CONF_ENABLE_GAP_FILLING,
                     first_profile.data.get(CONF_ENABLE_GAP_FILLING, DEFAULT_ENABLE_GAP_FILLING)
                 ),
+                CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS: first_profile.options.get(
+                    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                    first_profile.data.get(
+                        CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                        DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                    ),
+                ),
+                CONF_ENABLE_CALCULATOR_TOOLS: first_profile.options.get(
+                    CONF_ENABLE_CALCULATOR_TOOLS,
+                    first_profile.data.get(
+                        CONF_ENABLE_CALCULATOR_TOOLS,
+                        DEFAULT_ENABLE_CALCULATOR_TOOLS,
+                    ),
+                ),
+                CONF_ENABLE_UNIT_CONVERSION_TOOLS: first_profile.options.get(
+                    CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                    first_profile.data.get(
+                        CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                        DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
+                    ),
+                ),
             }
         else:
             # No profiles exist yet (shouldn't happen in normal flow), use defaults
@@ -129,6 +177,9 @@ async def ensure_system_entry(hass: HomeAssistant) -> ConfigEntry:
                 CONF_BRAVE_API_KEY: DEFAULT_BRAVE_API_KEY,
                 CONF_ALLOWED_IPS: DEFAULT_ALLOWED_IPS,
                 CONF_ENABLE_GAP_FILLING: DEFAULT_ENABLE_GAP_FILLING,
+                CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS: DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                CONF_ENABLE_CALCULATOR_TOOLS: DEFAULT_ENABLE_CALCULATOR_TOOLS,
+                CONF_ENABLE_UNIT_CONVERSION_TOOLS: DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
             }
 
         # Create system entry with extracted/default settings
@@ -165,6 +216,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _migrate_brave_search_tool_name(hass, entry)
 
     hass.data.setdefault(DOMAIN, {})
+
+    if not hass.services.has_service(DOMAIN, SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS,
+            _async_handle_reload_external_custom_tools,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
 
     # Ensure system entry exists (creates with defaults if not)
     await ensure_system_entry(hass)
@@ -329,6 +388,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             mcp_server = hass.data[DOMAIN].pop("shared_mcp_server", None)
             if mcp_server:
                 await mcp_server.stop()
+            if hass.services.has_service(DOMAIN, SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS):
+                hass.services.async_remove(DOMAIN, SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS)
             hass.data[DOMAIN].pop("index_manager", None)
             hass.data[DOMAIN].pop("mcp_port", None)
             hass.data[DOMAIN].pop("mcp_refcount", None)

--- a/custom_components/mcp_assist/config_flow.py
+++ b/custom_components/mcp_assist/config_flow.py
@@ -47,6 +47,9 @@ from .const import (
     CONF_MAX_ITERATIONS,
     CONF_DEBUG_MODE,
     CONF_ENABLE_CUSTOM_TOOLS,
+    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+    CONF_ENABLE_CALCULATOR_TOOLS,
+    CONF_ENABLE_UNIT_CONVERSION_TOOLS,
     CONF_BRAVE_API_KEY,
     CONF_ALLOWED_IPS,
     CONF_SEARCH_PROVIDER,
@@ -95,6 +98,9 @@ from .const import (
     DEFAULT_MAX_ITERATIONS,
     DEFAULT_DEBUG_MODE,
     DEFAULT_ENABLE_CUSTOM_TOOLS,
+    DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+    DEFAULT_ENABLE_CALCULATOR_TOOLS,
+    DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
     DEFAULT_BRAVE_API_KEY,
     DEFAULT_ALLOWED_IPS,
     DEFAULT_SEARCH_PROVIDER,
@@ -758,6 +764,18 @@ class MCPAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             CONF_ENABLE_GAP_FILLING: existing_entry.data.get(
                                 CONF_ENABLE_GAP_FILLING, DEFAULT_ENABLE_GAP_FILLING
                             ),
+                            CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS: existing_entry.data.get(
+                                CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                                DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                            ),
+                            CONF_ENABLE_CALCULATOR_TOOLS: existing_entry.data.get(
+                                CONF_ENABLE_CALCULATOR_TOOLS,
+                                DEFAULT_ENABLE_CALCULATOR_TOOLS,
+                            ),
+                            CONF_ENABLE_UNIT_CONVERSION_TOOLS: existing_entry.data.get(
+                                CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                                DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
+                            ),
                         }
 
                     # Combine data from steps 1-4 + shared settings
@@ -1016,6 +1034,18 @@ class MCPAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_ALLOWED_IPS, default=DEFAULT_ALLOWED_IPS): str,
                 vol.Optional(
                     CONF_ENABLE_GAP_FILLING, default=DEFAULT_ENABLE_GAP_FILLING
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                    default=DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_CALCULATOR_TOOLS,
+                    default=DEFAULT_ENABLE_CALCULATOR_TOOLS,
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                    default=DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
                 ): bool,
                 vol.Optional(
                     CONF_MAX_ENTITIES_PER_DISCOVERY,
@@ -1618,6 +1648,36 @@ class MCPAssistOptionsFlow(config_entries.OptionsFlow):
                         CONF_ENABLE_GAP_FILLING,
                         sys_data.get(
                             CONF_ENABLE_GAP_FILLING, DEFAULT_ENABLE_GAP_FILLING
+                        ),
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                    default=sys_options.get(
+                        CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                        sys_data.get(
+                            CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                            DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                        ),
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_CALCULATOR_TOOLS,
+                    default=sys_options.get(
+                        CONF_ENABLE_CALCULATOR_TOOLS,
+                        sys_data.get(
+                            CONF_ENABLE_CALCULATOR_TOOLS,
+                            DEFAULT_ENABLE_CALCULATOR_TOOLS,
+                        ),
+                    ),
+                ): bool,
+                vol.Optional(
+                    CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                    default=sys_options.get(
+                        CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                        sys_data.get(
+                            CONF_ENABLE_UNIT_CONVERSION_TOOLS,
+                            DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS,
                         ),
                     ),
                 ): bool,

--- a/custom_components/mcp_assist/const.py
+++ b/custom_components/mcp_assist/const.py
@@ -33,6 +33,9 @@ CONF_MAX_HISTORY = "max_history"
 CONF_MAX_ITERATIONS = "max_iterations"
 CONF_DEBUG_MODE = "debug_mode"
 CONF_ENABLE_CUSTOM_TOOLS = "enable_custom_tools"
+CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS = "enable_external_custom_tools"
+CONF_ENABLE_CALCULATOR_TOOLS = "enable_calculator_tools"
+CONF_ENABLE_UNIT_CONVERSION_TOOLS = "enable_unit_conversion_tools"
 CONF_BRAVE_API_KEY = "brave_api_key"
 CONF_ALLOWED_IPS = "allowed_ips"
 CONF_SEARCH_PROVIDER = "search_provider"
@@ -81,6 +84,9 @@ DEFAULT_MAX_HISTORY = 10
 DEFAULT_MAX_ITERATIONS = 10
 DEFAULT_DEBUG_MODE = False
 DEFAULT_ENABLE_CUSTOM_TOOLS = False
+DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS = False
+DEFAULT_ENABLE_CALCULATOR_TOOLS = False
+DEFAULT_ENABLE_UNIT_CONVERSION_TOOLS = False
 DEFAULT_BRAVE_API_KEY = ""
 DEFAULT_ALLOWED_IPS = ""
 DEFAULT_SEARCH_PROVIDER = "none"
@@ -91,6 +97,14 @@ DEFAULT_FOLLOW_UP_PHRASES = "anything else, what else, would you, do you, should
 DEFAULT_END_WORDS = "stop, cancel, no, nope, thanks, thank you, bye, goodbye, done, never mind, nevermind, forget it, that's all, that's it"
 DEFAULT_CLEAN_RESPONSES = False
 DEFAULT_TIMEOUT = 30
+
+# Manifest-based custom tool package support
+CUSTOM_TOOLS_DIRECTORY = "mcp-assist-tools"
+CUSTOM_TOOL_SHARED_DIRECTORY = "__shared__"
+CUSTOM_TOOL_SETTINGS_DIRECTORY = "mcp-assist-tool-settings"
+CUSTOM_TOOL_SCHEMA_VERSION = 1
+CUSTOM_TOOL_MANIFEST_FILENAME = "mcp_tool.json"
+SERVICE_RELOAD_EXTERNAL_CUSTOM_TOOLS = "reload_external_custom_tools"
 
 # MCP Server settings
 MCP_SERVER_NAME = "ha-entity-discovery"

--- a/custom_components/mcp_assist/custom_tool_api.py
+++ b/custom_components/mcp_assist/custom_tool_api.py
@@ -1,0 +1,289 @@
+"""Public API for user-defined MCP Assist custom tools.
+
+This module is intentionally stable and documented so local tools placed under
+the Home Assistant config directory can import it directly:
+
+    <home-assistant-config>/mcp-assist-tools/<tool_id>/tool.py
+
+Tool-package metadata should live in:
+
+    <home-assistant-config>/mcp-assist-tools/<tool_id>/mcp_tool.json
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, field
+import hashlib
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .const import CUSTOM_TOOL_SHARED_DIRECTORY, CUSTOM_TOOLS_DIRECTORY, DOMAIN
+
+_CURRENT_EXTERNAL_TOOL_CALL_CONTEXT: ContextVar[dict[str, Any] | None] = ContextVar(
+    "mcp_assist_external_tool_call_context",
+    default=None,
+)
+_EXTERNAL_SHARED_MODULE_CACHE: dict[str, tuple[int, str]] = {}
+
+
+@dataclass(frozen=True)
+class MCPAssistCustomToolManifest:
+    """Validated metadata for a user-defined custom tool package."""
+
+    schema_version: int
+    tool_id: str
+    name: str
+    description: str
+    version: str
+    entrypoint: str
+    capabilities: tuple[str, ...] = field(default_factory=tuple)
+    prompt_append_file: str | None = None
+
+
+class MCPAssistExternalTool:
+    """Base class for user-defined MCP Assist custom tool packages.
+
+    Custom tool packages should subclass this class and implement:
+    - get_tool_definitions()
+    - handle_call()
+
+    Optional hooks:
+    - initialize()
+    - async_shutdown()
+    - get_prompt_instructions()
+    - get_settings_schema()
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        manifest: MCPAssistCustomToolManifest,
+        tool_dir: Path,
+    ) -> None:
+        """Initialize the external tool instance."""
+        self.hass = hass
+        self.manifest = manifest
+        self.tool_dir = tool_dir
+        self.settings: dict[str, Any] = {}
+
+    async def initialize(self) -> None:
+        """Initialize the tool package.
+
+        Override when the tool needs lightweight setup such as reading a local
+        config file or preparing cached state.
+        """
+
+    async def async_shutdown(self) -> None:
+        """Clean up any tool resources before MCP Assist shuts down."""
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return MCP tool definitions exposed by this package."""
+        raise NotImplementedError
+
+    def get_settings_schema(self) -> dict[str, Any]:
+        """Return an optional shared-settings schema for this package.
+
+        When provided, MCP Assist will load package settings from
+        `<config>/mcp-assist-tool-settings/<tool_id>.json`, validate them, and
+        make the merged shared/profile settings available via `get_settings()`.
+        """
+
+        return {}
+
+    def handles_tool(self, tool_name: str) -> bool:
+        """Return whether this package handles the given tool name."""
+        return tool_name in {
+            str(tool.get("name") or "")
+            for tool in self.get_tool_definitions()
+        }
+
+    async def handle_call(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Handle a tool call and return standard MCP content."""
+        raise NotImplementedError
+
+    def get_prompt_instructions(self) -> str:
+        """Return optional prompt instructions for the LLM.
+
+        Keep this short and procedural. The loader will append the returned
+        text to the technical instructions only when external custom tools are
+        enabled.
+        """
+
+        return ""
+
+    def get_settings(self) -> dict[str, Any]:
+        """Return the effective settings for the current tool call."""
+        context = self.get_call_context()
+        settings = context.get("settings") if isinstance(context, dict) else None
+        if isinstance(settings, dict):
+            return dict(settings)
+        return dict(self.settings)
+
+    def get_shared_settings(self) -> dict[str, Any]:
+        """Return the package's shared settings."""
+        return dict(self.settings)
+
+    def get_profile_settings(self) -> dict[str, Any]:
+        """Return the current profile override settings, if any."""
+        context = self.get_call_context()
+        profile_settings = (
+            context.get("profile_settings") if isinstance(context, dict) else None
+        )
+        if isinstance(profile_settings, dict):
+            return dict(profile_settings)
+        return {}
+
+    def get_call_context(self) -> dict[str, Any]:
+        """Return MCP Assist metadata for the current tool call."""
+        return get_external_tool_call_context()
+
+    async def call_mcp_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Invoke any MCP Assist tool using the current profile call context."""
+        return await call_mcp_tool(
+            self.hass,
+            tool_name,
+            arguments,
+            context=self.get_call_context(),
+        )
+
+    def _set_loaded_settings(self, settings: dict[str, Any]) -> None:
+        """Internal helper used by the loader to attach validated settings."""
+        self.settings = dict(settings or {})
+
+    def _push_call_context(self, context: dict[str, Any] | None) -> Token:
+        """Internal helper used by the loader to scope call metadata."""
+        return _CURRENT_EXTERNAL_TOOL_CALL_CONTEXT.set(dict(context or {}))
+
+    def _reset_call_context(self, token: Token) -> None:
+        """Internal helper used by the loader to restore prior call metadata."""
+        _CURRENT_EXTERNAL_TOOL_CALL_CONTEXT.reset(token)
+
+
+def load_external_shared_module(
+    caller_file: str | Path,
+    module_name: str,
+) -> Any:
+    """Load a reusable helper module from `<config>/mcp-assist-tools/__shared__`.
+
+    This lets multiple narrow external tool packages share code without custom
+    `sys.path` shims.
+    """
+
+    caller_path = Path(caller_file).resolve()
+    tools_root = _find_external_tools_root(caller_path)
+    shared_root = (tools_root / CUSTOM_TOOL_SHARED_DIRECTORY).resolve()
+    if not shared_root.is_dir():
+        raise ImportError(
+            f"Shared helper directory does not exist: {shared_root}"
+        )
+
+    relative_path = Path(*module_name.split("."))
+    module_path = (shared_root / relative_path).with_suffix(".py")
+    if not module_path.is_file():
+        module_path = shared_root / relative_path / "__init__.py"
+    if not module_path.is_file():
+        raise ImportError(
+            f"Unable to resolve shared helper module {module_name!r} in {shared_root}"
+        )
+
+    try:
+        module_path.resolve().relative_to(shared_root)
+    except ValueError as err:
+        raise ImportError("Shared helper module must stay within __shared__") from err
+
+    module_path = module_path.resolve()
+    module_cache_key = str(module_path)
+    module_mtime_ns = module_path.stat().st_mtime_ns
+    cached = _EXTERNAL_SHARED_MODULE_CACHE.get(module_cache_key)
+    if cached is not None:
+        cached_mtime_ns, cached_module_name = cached
+        if cached_mtime_ns == module_mtime_ns:
+            module = sys.modules.get(cached_module_name)
+            if module is not None:
+                return module
+        else:
+            sys.modules.pop(cached_module_name, None)
+
+    path_hash = hashlib.sha1(module_cache_key.encode("utf-8")).hexdigest()[:12]
+    unique_module_name = (
+        f"mcp_assist_external_tools.shared.{module_name.replace('.', '_')}.{path_hash}_{module_mtime_ns}"
+    )
+    module = sys.modules.get(unique_module_name)
+    if module is not None:
+        _EXTERNAL_SHARED_MODULE_CACHE[module_cache_key] = (
+            module_mtime_ns,
+            unique_module_name,
+        )
+        return module
+
+    spec = importlib.util.spec_from_file_location(unique_module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to import shared helper from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique_module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(unique_module_name, None)
+        raise
+    _EXTERNAL_SHARED_MODULE_CACHE[module_cache_key] = (
+        module_mtime_ns,
+        unique_module_name,
+    )
+    return module
+
+
+def get_external_tool_call_context() -> dict[str, Any]:
+    """Return the current scoped external-tool call context."""
+    context = _CURRENT_EXTERNAL_TOOL_CALL_CONTEXT.get()
+    if isinstance(context, dict):
+        return dict(context)
+    return {}
+
+
+async def call_mcp_tool(
+    hass: HomeAssistant,
+    tool_name: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Invoke any MCP Assist tool through the shared MCP server."""
+    server = hass.data.get(DOMAIN, {}).get("shared_mcp_server")
+    if server is None:
+        raise RuntimeError("Shared MCP server is not running.")
+
+    handle_tool_call = getattr(server, "handle_tool_call", None)
+    if not callable(handle_tool_call):
+        raise RuntimeError(
+            "This MCP Assist build does not support tool invocation from external packages."
+        )
+
+    return await handle_tool_call(
+        {
+            "name": tool_name,
+            "arguments": dict(arguments or {}),
+            "context": dict(context or {}),
+        }
+    )
+
+
+def _find_external_tools_root(caller_path: Path) -> Path:
+    for candidate in [caller_path.parent, *caller_path.parents]:
+        if candidate.name == CUSTOM_TOOLS_DIRECTORY:
+            return candidate
+    raise ImportError(
+        f"Unable to locate {CUSTOM_TOOLS_DIRECTORY!r} from {caller_path}"
+    )

--- a/custom_components/mcp_assist/custom_tools/__init__.py
+++ b/custom_components/mcp_assist/custom_tools/__init__.py
@@ -1,84 +1,234 @@
-"""Custom tools loader for MCP Assist."""
+"""Built-in and external custom tool loading for MCP Assist."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
 import logging
-from typing import Dict, Any, List
+from pathlib import Path
+from typing import Any
+
+from ..custom_tool_api import MCPAssistExternalTool
+from ..const import (
+    CONF_BRAVE_API_KEY,
+    CONF_ENABLE_CUSTOM_TOOLS,
+    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+    CONF_SEARCH_PROVIDER,
+    DEFAULT_BRAVE_API_KEY,
+    DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+)
+from .builtin_catalog import (
+    BuiltInToolToggleSpec,
+    get_builtin_toggle_spec_by_tool_name,
+    is_builtin_package_enabled_for_shared_settings,
+    load_builtin_tool_toggle_specs,
+)
+from .external_loader import (
+    ExternalCustomToolLoader,
+    LoadedToolPackage,
+    combine_prompt_instructions,
+)
+from .schema_utils import SchemaValidationError, validate_and_normalize_json_value
 
 _LOGGER = logging.getLogger(__name__)
 
+
+@dataclass
+class _RegisteredTool:
+    """Validated custom-tool registry entry."""
+
+    name: str
+    definition: dict[str, Any]
+    instance: Any
+    provider_key: str
+    is_external: bool
+    loaded_tool_package: LoadedToolPackage | None = None
+    package_loader: ExternalCustomToolLoader | None = None
+
+
 class CustomToolsLoader:
-    """Load and manage custom tools."""
+    """Load and manage built-in and user-defined custom tools."""
 
     def __init__(self, hass, entry=None):
         """Initialize the custom tools loader."""
         self.hass = hass
         self.entry = entry
-        self.tools = {}
+        self.tools: dict[str, Any] = {}
+        self.builtin_packages: list[LoadedToolPackage] = []
+        self.external_tools: list[LoadedToolPackage] = []
+        self._builtin_loader = ExternalCustomToolLoader(
+            self.hass,
+            tools_root=Path(__file__).resolve().parent / "packages",
+            module_namespace="mcp_assist_builtin_tools",
+            require_tool_name_prefix=False,
+            package_log_label="built-in tool package",
+            prompt_package_label="Built-in tool package",
+            prompt_chars_per_tool=420,
+        )
+        self._external_loader = ExternalCustomToolLoader(self.hass)
+        self._builtin_toggle_specs: tuple[BuiltInToolToggleSpec, ...] = ()
+        self._builtin_prompt_instructions = ""
+        self._external_prompt_instructions = ""
+        self._tool_registry: dict[str, _RegisteredTool] = {}
+        self._tool_definitions_cache: list[dict[str, Any]] = []
 
     async def initialize(self):
-        """Initialize custom tools based on search provider selection."""
-        # Determine search provider
+        """Initialize built-in bundles and optional external tool packages."""
+        await self._load_builtin_toggle_specs()
+        await self._initialize_builtin_tools()
+        await self._initialize_external_tools()
+        self._refresh_tool_registry()
+
+    async def _load_builtin_toggle_specs(self) -> None:
+        """Load built-in package toggle metadata from the package manifests."""
+        self._builtin_toggle_specs = await self.hass.async_add_executor_job(
+            load_builtin_tool_toggle_specs
+        )
+
+    async def _initialize_builtin_tools(self) -> None:
+        """Load built-in tool bundles that ship with MCP Assist."""
+        await self._shutdown_builtin_tools()
+
         search_provider = self._get_search_provider()
+        selected_tool_ids = {
+            spec.package_id
+            for spec in self._builtin_toggle_specs
+            if is_builtin_package_enabled_for_shared_settings(
+                spec,
+                self._get_shared_setting,
+                search_provider=search_provider,
+            )
+        }
 
-        # Load search tool based on provider
-        if search_provider == "brave":
-            try:
-                from .brave_search import BraveSearchTool
-                # Get Brave API key from system entry (shared setting)
-                api_key = self._get_brave_api_key()
-                self.tools["search"] = BraveSearchTool(self.hass, api_key)
-                await self.tools["search"].initialize()
-                _LOGGER.debug("✅ Brave Search tool initialized")
-            except Exception as e:
-                _LOGGER.error(f"Failed to initialize Brave Search tool: {e}")
+        if not selected_tool_ids:
+            self._builtin_prompt_instructions = ""
+            return
 
-        elif search_provider == "duckduckgo":
-            try:
-                from .duckduckgo_search import DuckDuckGoSearchTool
-                self.tools["search"] = DuckDuckGoSearchTool(self.hass)
-                await self.tools["search"].initialize()
-                _LOGGER.debug("✅ DuckDuckGo Search tool initialized")
-            except Exception as e:
-                _LOGGER.error(f"Failed to initialize DuckDuckGo Search tool: {e}")
+        self.builtin_packages = await self._builtin_loader.load(
+            allowed_tool_ids=selected_tool_ids,
+        )
+        for loaded_tool in self.builtin_packages:
+            self.tools[loaded_tool.manifest.tool_id] = loaded_tool.instance
+        self._builtin_prompt_instructions = combine_prompt_instructions(
+            self.builtin_packages,
+            heading="## Optional Built-In Tool Packages",
+            truncated_notice="[Built-in tool package instructions truncated.]",
+        )
 
-        # Load read_url tool if search is enabled
-        if search_provider in ["brave", "duckduckgo"]:
+        if self.builtin_packages:
+            _LOGGER.info(
+                "✅ Loaded %d built-in tool package(s)",
+                len(self.builtin_packages),
+            )
+
+    async def _initialize_external_tools(self) -> None:
+        """Load opt-in user-defined tool packages from the HA config directory."""
+        await self._shutdown_external_tools()
+
+        if not self._external_custom_tools_enabled():
+            _LOGGER.debug("External custom tools disabled in shared MCP settings")
+            self.external_tools = []
+            self._external_prompt_instructions = ""
+            return
+
+        reserved_tool_names = {
+            str(tool_definition.get("name") or "")
+            for tool_definition in self._get_builtin_tool_definitions()
+        }
+        reserved_tool_ids = {
+            loaded_tool.manifest.tool_id for loaded_tool in self.builtin_packages
+        }
+        self.external_tools = await self._external_loader.load(
+            reserved_tool_names=reserved_tool_names,
+            reserved_tool_ids=reserved_tool_ids,
+        )
+        for loaded_tool in self.external_tools:
+            self.tools[loaded_tool.manifest.tool_id] = loaded_tool.instance
+
+        self._external_prompt_instructions = combine_prompt_instructions(
+            self.external_tools
+        )
+        if self.external_tools:
+            _LOGGER.info(
+                "✅ Loaded %d external custom tool package(s) from %s",
+                len(self.external_tools),
+                self._external_loader.get_tools_root(),
+            )
+        else:
+            _LOGGER.info("No external custom tool packages were loaded")
+
+    async def shutdown(self) -> None:
+        """Shut down any loaded tool packages cleanly."""
+        await self._shutdown_builtin_tools()
+        await self._shutdown_external_tools()
+
+    async def _shutdown_builtin_tools(self) -> None:
+        """Shut down the currently loaded built-in tool packages."""
+        for loaded_tool in self.builtin_packages:
             try:
-                from .read_url import ReadUrlTool
-                self.tools["read_url"] = ReadUrlTool(self.hass)
-                await self.tools["read_url"].initialize()
-                _LOGGER.debug("✅ Read URL tool initialized")
-            except Exception as e:
-                _LOGGER.error(f"Failed to initialize read_url tool: {e}")
+                await loaded_tool.instance.async_shutdown()
+            except Exception as err:
+                _LOGGER.warning(
+                    "Built-in tool package %s failed during shutdown: %s",
+                    loaded_tool.manifest.tool_id,
+                    err,
+                )
+            finally:
+                self.tools.pop(loaded_tool.manifest.tool_id, None)
+
+        self.builtin_packages = []
+        self._builtin_prompt_instructions = ""
+
+    async def _shutdown_external_tools(self) -> None:
+        """Shut down only the currently loaded external custom tool packages."""
+        for loaded_tool in self.external_tools:
+            try:
+                await loaded_tool.instance.async_shutdown()
+            except Exception as err:
+                _LOGGER.warning(
+                    "External custom tool %s failed during shutdown: %s",
+                    loaded_tool.manifest.tool_id,
+                    err,
+                )
+            finally:
+                self.tools.pop(loaded_tool.manifest.tool_id, None)
+
+        self.external_tools = []
+        self._external_prompt_instructions = ""
 
     def _get_shared_setting(self, key: str, default: Any = None) -> Any:
         """Get a shared setting from system entry with fallback to profile entry."""
-        # Import here to avoid circular dependency
         from .. import get_system_entry
 
-        # Try to get from system entry first
         system_entry = get_system_entry(self.hass)
         if system_entry:
             value = system_entry.options.get(key, system_entry.data.get(key))
             if value is not None:
                 return value
 
-        # Fallback to profile entry for backward compatibility
         if self.entry:
             value = self.entry.options.get(key, self.entry.data.get(key))
             if value is not None:
                 return value
 
-        # Return default
         return default
+
+    def _external_custom_tools_enabled(self) -> bool:
+        """Return whether user-defined external tool packages are enabled."""
+        return bool(
+            self._get_shared_setting(
+                CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+            )
+        )
 
     def _get_search_provider(self) -> str:
         """Get search provider (shared setting) with backward compatibility."""
-        from ..const import CONF_SEARCH_PROVIDER, CONF_ENABLE_CUSTOM_TOOLS
-
         provider = self._get_shared_setting(CONF_SEARCH_PROVIDER)
         if provider:
             return provider
 
-        # Backward compat: if old enable_custom_tools was True, default to "brave"
+        # Backward compat: older versions used enable_custom_tools for Brave search.
         if self._get_shared_setting(CONF_ENABLE_CUSTOM_TOOLS, False):
             return "brave"
 
@@ -86,30 +236,377 @@ class CustomToolsLoader:
 
     def _get_brave_api_key(self) -> str:
         """Get Brave API key (shared setting)."""
-        from ..const import CONF_BRAVE_API_KEY, DEFAULT_BRAVE_API_KEY
         return self._get_shared_setting(CONF_BRAVE_API_KEY, DEFAULT_BRAVE_API_KEY)
 
-    def get_tool_definitions(self) -> List[Dict[str, Any]]:
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
         """Get MCP tool definitions for all enabled tools."""
-        definitions = []
-        for tool in self.tools.values():
-            try:
-                definitions.extend(tool.get_tool_definitions())
-            except Exception as e:
-                _LOGGER.error(f"Error getting tool definitions: {e}")
-        return definitions
+        if not self._tool_definitions_cache:
+            self._refresh_tool_registry()
+        return list(self._tool_definitions_cache)
 
-    async def handle_tool_call(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+    async def handle_tool_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Handle a custom tool call."""
-        for tool in self.tools.values():
-            if tool.handles_tool(tool_name):
-                return await tool.handle_call(tool_name, arguments)
+        registry_entry = self._tool_registry.get(tool_name)
+        if registry_entry is None:
+            raise ValueError(f"Unknown custom tool: {tool_name}")
 
-        raise ValueError(f"Unknown custom tool: {tool_name}")
+        normalized_arguments = dict(arguments or {})
+        if registry_entry.loaded_tool_package is not None:
+            try:
+                normalized_arguments = validate_and_normalize_json_value(
+                    registry_entry.definition.get("inputSchema") or {},
+                    normalized_arguments,
+                    path=f"{tool_name} arguments",
+                )
+            except SchemaValidationError as err:
+                return self._build_error_result(str(err))
+
+            return await self._handle_package_tool_call(
+                registry_entry,
+                tool_name,
+                normalized_arguments,
+                context=context,
+            )
+
+        return await registry_entry.instance.handle_call(tool_name, normalized_arguments)
 
     def is_custom_tool(self, tool_name: str) -> bool:
-        """Check if a tool name is a custom tool."""
-        for tool in self.tools.values():
-            if tool.handles_tool(tool_name):
-                return True
-        return False
+        """Check if a tool name is provided by the custom tool loader."""
+        return tool_name in self._tool_registry
+
+    def is_external_custom_tool(self, tool_name: str) -> bool:
+        """Check if a tool name comes from an external custom tool package."""
+        registry_entry = self._tool_registry.get(tool_name)
+        return bool(registry_entry and registry_entry.is_external)
+
+    def is_builtin_custom_tool(self, tool_name: str) -> bool:
+        """Check if a tool name comes from a built-in packaged tool."""
+        registry_entry = self._tool_registry.get(tool_name)
+        return bool(
+            registry_entry
+            and registry_entry.loaded_tool_package is not None
+            and not registry_entry.is_external
+        )
+
+    def get_builtin_toggle_specs(self) -> tuple[BuiltInToolToggleSpec, ...]:
+        """Return built-in packaged-tool toggle metadata."""
+        return self._builtin_toggle_specs
+
+    def get_builtin_toggle_spec(
+        self, tool_name: str
+    ) -> BuiltInToolToggleSpec | None:
+        """Return built-in package toggle metadata for a tool name."""
+        return get_builtin_toggle_spec_by_tool_name(
+            tool_name,
+            self._builtin_toggle_specs,
+        )
+
+    def get_builtin_prompt_instructions(self) -> str:
+        """Return aggregated prompt additions from loaded built-in tool packages."""
+        return self._builtin_prompt_instructions
+
+    def get_external_prompt_instructions(self) -> str:
+        """Return aggregated prompt additions from loaded external tool packages."""
+        return self._external_prompt_instructions
+
+    def get_cache_signature(self) -> tuple[Any, ...]:
+        """Return a stable cache signature for the current tool surface."""
+        try:
+            tool_definitions = tuple(
+                json.dumps(tool_definition, sort_keys=True, separators=(",", ":"))
+                for tool_definition in self.get_tool_definitions()
+            )
+        except Exception as err:
+            _LOGGER.debug("Unable to serialize tool definitions for cache key: %s", err)
+            tool_definitions = ()
+
+        try:
+            builtin_prompt_instructions = self.get_builtin_prompt_instructions()
+        except Exception as err:
+            _LOGGER.debug(
+                "Unable to read built-in prompt instructions for cache key: %s", err
+            )
+            builtin_prompt_instructions = ""
+
+        try:
+            external_prompt_instructions = self.get_external_prompt_instructions()
+        except Exception as err:
+            _LOGGER.debug(
+                "Unable to read external prompt instructions for cache key: %s", err
+            )
+            external_prompt_instructions = ""
+
+        return (
+            tool_definitions,
+            builtin_prompt_instructions,
+            external_prompt_instructions,
+        )
+
+    async def reload_external_tools(self) -> dict[str, Any]:
+        """Backward-compatible alias that reloads all manifest-based tool packages."""
+        return await self.reload_tool_packages()
+
+    async def reload_tool_packages(self) -> dict[str, Any]:
+        """Reload built-in and external manifest-based tool packages."""
+        await self._load_builtin_toggle_specs()
+        await self._initialize_builtin_tools()
+        await self._initialize_external_tools()
+        self._refresh_tool_registry()
+        return self.get_package_diagnostics()
+
+    def get_loaded_builtin_tool_info(self) -> list[dict[str, Any]]:
+        """Return metadata for loaded built-in tool packages."""
+        return [
+            {
+                "id": loaded_tool.manifest.tool_id,
+                "name": loaded_tool.manifest.name,
+                "version": loaded_tool.manifest.version,
+                "description": loaded_tool.manifest.description,
+                "tool_names": list(loaded_tool.tool_names),
+                "capabilities": list(loaded_tool.manifest.capabilities),
+            }
+            for loaded_tool in self.builtin_packages
+        ]
+
+    def get_package_diagnostics(self) -> dict[str, Any]:
+        """Return diagnostics for all manifest-based tool packages."""
+        return {
+            "built_in_tools_root": str(self._builtin_loader.get_tools_root()),
+            "built_in_last_loaded_at": self._builtin_loader.last_loaded_at,
+            "built_in_scanned_packages": list(self._builtin_loader.last_scanned_packages),
+            "built_in_load_errors": list(self._builtin_loader.last_load_errors),
+            "built_in_packages": [
+                {
+                    "id": loaded_tool.manifest.tool_id,
+                    "name": loaded_tool.manifest.name,
+                    "version": loaded_tool.manifest.version,
+                    "tool_names": list(loaded_tool.tool_names),
+                    "capabilities": list(loaded_tool.manifest.capabilities),
+                    "prompt_instructions": loaded_tool.prompt_instructions,
+                    "shared_settings_path": loaded_tool.shared_settings_path,
+                    "has_settings_schema": bool(loaded_tool.settings_schema),
+                }
+                for loaded_tool in self.builtin_packages
+            ],
+            "built_in_prompt_instructions": self._builtin_prompt_instructions,
+            "external_custom_tools_enabled": self._external_custom_tools_enabled(),
+            "external_tools_root": str(self._external_loader.get_tools_root()),
+            "external_settings_root": str(self._external_loader.get_settings_root()),
+            "external_last_loaded_at": self._external_loader.last_loaded_at,
+            "external_scanned_packages": list(self._external_loader.last_scanned_packages),
+            "external_load_errors": list(self._external_loader.last_load_errors),
+            "external_packages": [
+                {
+                    "id": loaded_tool.manifest.tool_id,
+                    "name": loaded_tool.manifest.name,
+                    "version": loaded_tool.manifest.version,
+                    "tool_names": list(loaded_tool.tool_names),
+                    "capabilities": list(loaded_tool.manifest.capabilities),
+                    "prompt_instructions": loaded_tool.prompt_instructions,
+                    "shared_settings_path": loaded_tool.shared_settings_path,
+                    "has_settings_schema": bool(loaded_tool.settings_schema),
+                }
+                for loaded_tool in self.external_tools
+            ],
+        }
+
+    def get_external_diagnostics(self) -> dict[str, Any]:
+        """Return detailed diagnostics for external custom-tool loading."""
+        package_diagnostics = self.get_package_diagnostics()
+        return {
+            "enabled": package_diagnostics["external_custom_tools_enabled"],
+            "tools_root": package_diagnostics["external_tools_root"],
+            "settings_root": package_diagnostics["external_settings_root"],
+            "last_loaded_at": package_diagnostics["external_last_loaded_at"],
+            "scanned_packages": package_diagnostics["external_scanned_packages"],
+            "load_errors": package_diagnostics["external_load_errors"],
+            "loaded_tools": [
+                {
+                    **loaded_tool,
+                }
+                for loaded_tool in package_diagnostics["external_packages"]
+            ],
+            "built_in_tools_root": package_diagnostics["built_in_tools_root"],
+            "built_in_last_loaded_at": package_diagnostics["built_in_last_loaded_at"],
+            "built_in_scanned_packages": package_diagnostics["built_in_scanned_packages"],
+            "built_in_load_errors": package_diagnostics["built_in_load_errors"],
+            "built_in_packages": package_diagnostics["built_in_packages"],
+        }
+
+    def get_loaded_external_tool_info(self) -> list[dict[str, Any]]:
+        """Return metadata for loaded external tool packages."""
+        return [
+            {
+                "id": loaded_tool.manifest.tool_id,
+                "name": loaded_tool.manifest.name,
+                "version": loaded_tool.manifest.version,
+                "description": loaded_tool.manifest.description,
+                "tool_names": list(loaded_tool.tool_names),
+                "capabilities": list(loaded_tool.manifest.capabilities),
+            }
+            for loaded_tool in self.external_tools
+        ]
+
+    def _get_builtin_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return built-in MCP tool definitions for reserved-name checks."""
+        builtin_definitions: list[dict[str, Any]] = []
+        for loaded_tool in self.builtin_packages:
+            builtin_definitions.extend(loaded_tool.tool_definitions)
+        return builtin_definitions
+
+    def _refresh_tool_registry(self) -> None:
+        """Build a validated tool-name registry for dispatch and caching."""
+        registry: dict[str, _RegisteredTool] = {}
+        ordered_definitions: list[dict[str, Any]] = []
+        packaged_tool_keys = {
+            loaded_tool.manifest.tool_id
+            for loaded_tool in [*self.builtin_packages, *self.external_tools]
+        }
+
+        for tool_key, tool in self.tools.items():
+            if tool_key in packaged_tool_keys:
+                continue
+            try:
+                tool_definitions = tool.get_tool_definitions()
+            except Exception as err:
+                _LOGGER.error("Error getting tool definitions from %s: %s", tool_key, err)
+                continue
+
+            for tool_definition in tool_definitions:
+                tool_name = str(tool_definition.get("name") or "")
+                if not tool_name:
+                    continue
+                if tool_name in registry:
+                    _LOGGER.warning("Skipping duplicate custom tool definition %s", tool_name)
+                    continue
+                registry[tool_name] = _RegisteredTool(
+                    name=tool_name,
+                    definition=tool_definition,
+                    instance=tool,
+                    provider_key=tool_key,
+                    is_external=False,
+                )
+                ordered_definitions.append(tool_definition)
+
+        for loaded_tool in self.builtin_packages:
+            for tool_definition in loaded_tool.tool_definitions:
+                tool_name = str(tool_definition.get("name") or "")
+                if not tool_name:
+                    continue
+                if tool_name in registry:
+                    _LOGGER.warning(
+                        "Skipping duplicate built-in custom tool definition %s",
+                        tool_name,
+                    )
+                    continue
+                registry[tool_name] = _RegisteredTool(
+                    name=tool_name,
+                    definition=tool_definition,
+                    instance=loaded_tool.instance,
+                    provider_key=loaded_tool.manifest.tool_id,
+                    is_external=False,
+                    loaded_tool_package=loaded_tool,
+                    package_loader=self._builtin_loader,
+                )
+                ordered_definitions.append(tool_definition)
+
+        for loaded_tool in self.external_tools:
+            for tool_definition in loaded_tool.tool_definitions:
+                tool_name = str(tool_definition.get("name") or "")
+                if not tool_name:
+                    continue
+                if tool_name in registry:
+                    _LOGGER.warning(
+                        "Skipping duplicate external custom tool definition %s",
+                        tool_name,
+                    )
+                    continue
+                registry[tool_name] = _RegisteredTool(
+                    name=tool_name,
+                    definition=tool_definition,
+                    instance=loaded_tool.instance,
+                    provider_key=loaded_tool.manifest.tool_id,
+                    is_external=True,
+                    loaded_tool_package=loaded_tool,
+                    package_loader=self._external_loader,
+                )
+                ordered_definitions.append(tool_definition)
+
+        self._tool_registry = registry
+        self._tool_definitions_cache = ordered_definitions
+
+    async def _handle_package_tool_call(
+        self,
+        registry_entry: _RegisteredTool,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Execute a manifest-based tool package with scoped call context."""
+        loaded_tool = registry_entry.loaded_tool_package
+        package_loader = registry_entry.package_loader
+        instance = registry_entry.instance
+        if (
+            loaded_tool is None
+            or package_loader is None
+            or not isinstance(instance, MCPAssistExternalTool)
+        ):
+            return self._build_error_result(
+                f"Tool package for {tool_name!r} is not available right now."
+            )
+
+        call_context = dict(context or {})
+        profile_entry_id = str(call_context.get("profile_entry_id") or "").strip()
+        try:
+            (
+                effective_settings,
+                profile_settings,
+                profile_settings_path,
+            ) = await package_loader.load_profile_settings(
+                loaded_tool,
+                profile_entry_id,
+            )
+        except Exception as err:
+            _LOGGER.error(
+                "Failed to load settings for %s %s: %s",
+                "external custom tool" if registry_entry.is_external else "built-in tool package",
+                tool_name,
+                err,
+            )
+            return self._build_error_result(str(err))
+
+        call_context.update(
+            {
+                "tool_id": loaded_tool.manifest.tool_id,
+                "tool_name": tool_name,
+                "settings": effective_settings,
+                "shared_settings": loaded_tool.shared_settings,
+                "profile_settings": profile_settings,
+                "shared_settings_path": loaded_tool.shared_settings_path,
+                "profile_settings_path": profile_settings_path,
+            }
+        )
+
+        token = instance._push_call_context(call_context)
+        try:
+            return await instance.handle_call(tool_name, arguments)
+        except Exception as err:
+            _LOGGER.error("Error executing tool package %s: %s", tool_name, err)
+            return self._build_error_result(str(err))
+        finally:
+            instance._reset_call_context(token)
+
+    @staticmethod
+    def _build_error_result(message: str) -> dict[str, Any]:
+        """Return a standard MCP error payload."""
+        return {
+            "isError": True,
+            "content": [{"type": "text", "text": str(message)}],
+        }

--- a/custom_components/mcp_assist/custom_tools/builtin_catalog.py
+++ b/custom_components/mcp_assist/custom_tools/builtin_catalog.py
@@ -1,0 +1,232 @@
+"""Catalog helpers for built-in manifest-based MCP Assist tool packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+from ..const import CUSTOM_TOOL_MANIFEST_FILENAME
+
+
+@dataclass(frozen=True)
+class BuiltInToolToggleSpec:
+    """Enable/disable metadata declared by a built-in tool package."""
+
+    package_id: str
+    package_name: str
+    package_description: str
+    tool_names: tuple[str, ...]
+    shared_setting_key: str
+    profile_setting_key: str
+    shared_default: bool
+    profile_default: bool
+    shared_label: str
+    shared_description: str
+    profile_disable_label: str
+    profile_disable_description: str
+    legacy_shared_setting_keys: tuple[str, ...] = ()
+    legacy_profile_setting_keys: tuple[str, ...] = ()
+    requires_search_provider: bool = False
+
+
+def get_builtin_packages_root() -> Path:
+    """Return the built-in package directory."""
+    return Path(__file__).resolve().parent / "packages"
+
+
+def load_builtin_tool_toggle_specs(
+    packages_root: Path | None = None,
+) -> tuple[BuiltInToolToggleSpec, ...]:
+    """Load built-in tool toggle metadata from package manifests."""
+    root = packages_root or get_builtin_packages_root()
+    if not root.is_dir():
+        return ()
+
+    specs: list[BuiltInToolToggleSpec] = []
+    for package_dir in sorted(root.iterdir(), key=lambda item: item.name.casefold()):
+        if not package_dir.is_dir() or package_dir.name.startswith((".", "__")):
+            continue
+
+        manifest_path = package_dir / CUSTOM_TOOL_MANIFEST_FILENAME
+        if not manifest_path.is_file():
+            continue
+
+        raw_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(raw_manifest, dict):
+            continue
+
+        built_in = raw_manifest.get("built_in_toggle")
+        if not isinstance(built_in, dict):
+            continue
+
+        package_id = str(raw_manifest.get("id") or package_dir.name).strip()
+        package_name = str(raw_manifest.get("name") or package_id).strip() or package_id
+        package_description = str(raw_manifest.get("description") or "").strip()
+        tool_names_value = built_in.get("tool_names") or ()
+        if not isinstance(tool_names_value, (list, tuple)):
+            raise ValueError(
+                f"{manifest_path} built_in_toggle.tool_names must be a list of strings"
+            )
+        tool_names = tuple(
+            str(tool_name).strip()
+            for tool_name in tool_names_value
+            if str(tool_name).strip()
+        )
+        if not tool_names:
+            raise ValueError(f"{manifest_path} must declare built_in_toggle.tool_names")
+
+        shared_setting_key = str(built_in.get("shared_setting_key") or "").strip()
+        profile_setting_key = str(built_in.get("profile_setting_key") or "").strip()
+        if not shared_setting_key or not profile_setting_key:
+            raise ValueError(
+                f"{manifest_path} must declare built_in_toggle shared/profile setting keys"
+            )
+
+        shared_label = (
+            str(built_in.get("shared_label") or "").strip() or package_name
+        )
+        profile_disable_label = (
+            str(built_in.get("profile_disable_label") or "").strip()
+            or f"Disable {package_name}"
+        )
+
+        shared_description = str(built_in.get("shared_description") or "").strip()
+        profile_disable_description = str(
+            built_in.get("profile_disable_description") or ""
+        ).strip()
+
+        legacy_shared_setting_keys = tuple(
+            str(key).strip()
+            for key in tuple(built_in.get("legacy_shared_setting_keys") or ())
+            if str(key).strip()
+        )
+        legacy_profile_setting_keys = tuple(
+            str(key).strip()
+            for key in tuple(built_in.get("legacy_profile_setting_keys") or ())
+            if str(key).strip()
+        )
+
+        specs.append(
+            BuiltInToolToggleSpec(
+                package_id=package_id,
+                package_name=package_name,
+                package_description=package_description,
+                tool_names=tool_names,
+                shared_setting_key=shared_setting_key,
+                profile_setting_key=profile_setting_key,
+                shared_default=bool(built_in.get("shared_default", False)),
+                profile_default=bool(built_in.get("profile_default", True)),
+                shared_label=shared_label,
+                shared_description=shared_description,
+                profile_disable_label=profile_disable_label,
+                profile_disable_description=profile_disable_description,
+                legacy_shared_setting_keys=legacy_shared_setting_keys,
+                legacy_profile_setting_keys=legacy_profile_setting_keys,
+                requires_search_provider=bool(
+                    built_in.get("requires_search_provider", False)
+                ),
+            )
+        )
+
+    return tuple(specs)
+
+
+def get_builtin_toggle_spec_by_tool_name(
+    tool_name: str,
+    specs: tuple[BuiltInToolToggleSpec, ...],
+) -> BuiltInToolToggleSpec | None:
+    """Return the built-in toggle metadata for a tool name, if any."""
+    normalized_tool_name = str(tool_name or "").strip()
+    if not normalized_tool_name:
+        return None
+    for spec in specs:
+        if normalized_tool_name in spec.tool_names:
+            return spec
+    return None
+
+
+def get_builtin_toggle_spec_by_package_id(
+    package_id: str,
+    specs: tuple[BuiltInToolToggleSpec, ...],
+) -> BuiltInToolToggleSpec | None:
+    """Return the built-in toggle metadata for a package id, if any."""
+    normalized_package_id = str(package_id or "").strip()
+    if not normalized_package_id:
+        return None
+    for spec in specs:
+        if spec.package_id == normalized_package_id:
+            return spec
+    return None
+
+
+def get_builtin_shared_setting_value(
+    spec: BuiltInToolToggleSpec,
+    get_setting: Any,
+) -> Any:
+    """Resolve a built-in package shared setting with legacy fallback keys."""
+    value = get_setting(spec.shared_setting_key, None)
+    if value is not None:
+        return value
+
+    for legacy_key in spec.legacy_shared_setting_keys:
+        value = get_setting(legacy_key, None)
+        if value is not None:
+            return value
+
+    return spec.shared_default
+
+
+def get_builtin_profile_setting_value(
+    spec: BuiltInToolToggleSpec,
+    get_profile_setting: Any,
+) -> Any:
+    """Resolve a built-in package profile setting with legacy fallback keys."""
+    value = get_profile_setting(spec.profile_setting_key, None)
+    if value is not None:
+        return value
+
+    for legacy_key in spec.legacy_profile_setting_keys:
+        value = get_profile_setting(legacy_key, None)
+        if value is not None:
+            return value
+
+    return spec.profile_default
+
+
+def is_builtin_package_enabled_for_shared_settings(
+    spec: BuiltInToolToggleSpec,
+    get_setting: Any,
+    *,
+    search_provider: str = "none",
+) -> bool:
+    """Return whether a built-in package should be enabled by shared settings."""
+    if not bool(get_builtin_shared_setting_value(spec, get_setting)):
+        return False
+
+    if spec.requires_search_provider and search_provider not in {
+        "brave",
+        "duckduckgo",
+    }:
+        return False
+
+    return True
+
+
+def is_builtin_package_enabled_for_profile(
+    spec: BuiltInToolToggleSpec,
+    get_shared_setting: Any,
+    get_profile_setting: Any,
+    *,
+    search_provider: str = "none",
+) -> bool:
+    """Return whether a built-in package is enabled for a specific profile."""
+    return bool(
+        is_builtin_package_enabled_for_shared_settings(
+            spec,
+            get_shared_setting,
+            search_provider=search_provider,
+        )
+        and get_builtin_profile_setting_value(spec, get_profile_setting)
+    )

--- a/custom_components/mcp_assist/custom_tools/calculator.py
+++ b/custom_components/mcp_assist/custom_tools/calculator.py
@@ -1,0 +1,1188 @@
+"""Calculator and unit conversion custom tools for MCP Assist."""
+
+from __future__ import annotations
+
+import ast
+import logging
+import math
+import re
+from typing import Any, Dict, List
+
+_LOGGER = logging.getLogger(__name__)
+
+NUM_SCHEMA = {"type": "number"}
+STRING_SCHEMA = {"type": "string"}
+
+CALCULATOR_LLM_DESCRIPTIONS = {
+    "add": "Add numbers.",
+    "subtract": "Subtract one number from another.",
+    "multiply": "Multiply numbers.",
+    "divide": "Divide one number by another.",
+    "sqrt": "Take the square root of a number.",
+    "power": "Raise a number to a power.",
+    "round_number": "Round a number to a chosen number of decimals.",
+    "average": "Calculate the average of a list of numbers.",
+    "min_value": "Return the smallest number in a list.",
+    "max_value": "Return the largest number in a list.",
+    "convert_unit": "Convert between common units.",
+    "evaluate_expression": "Evaluate a math expression safely.",
+}
+
+
+CALCULATOR_TOOLS = [
+    {
+        "name": "add",
+        "description": "Add numbers. Accepts a and b, or a list like numbers=[1, 2, 3.5]. Example: add(a=10, b=3) returns 13.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "a": NUM_SCHEMA,
+                "b": NUM_SCHEMA,
+                "numbers": {"type": "array", "items": NUM_SCHEMA},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "subtract",
+        "description": "Subtract b from a. Example: subtract(a=10, b=3) returns 7.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "multiply",
+        "description": "Multiply numbers. Accepts a and b, or a list like operands=[2, 3, 4]. Example: multiply(a=247, b=83) returns 20501.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "a": NUM_SCHEMA,
+                "b": NUM_SCHEMA,
+                "operands": {"type": "array", "items": NUM_SCHEMA},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "divide",
+        "description": "Divide a by b. Example: divide(a=10, b=4) returns 2.5.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "sqrt",
+        "description": "Square root of a number. Example: sqrt(a=144) returns 12.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA},
+            "required": ["a"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "power",
+        "description": "Raise a to the power of b. Example: power(a=2, b=10) returns 1024.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {"a": NUM_SCHEMA, "b": NUM_SCHEMA},
+            "required": ["a", "b"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "round_number",
+        "description": "Round a number to a given number of decimal places. Example: round_number(a=3.14159, decimals=2) returns 3.14.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "a": NUM_SCHEMA,
+                "decimals": {"type": "integer"},
+            },
+            "required": ["a"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "average",
+        "description": "Calculate the arithmetic mean of numbers. Accepts a list such as numbers=[1, 2, 3]. Example: average(numbers=[1, 2, 3]) returns 2.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "numbers": {"type": "array", "items": NUM_SCHEMA},
+                "values": {"type": "array", "items": NUM_SCHEMA},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "min_value",
+        "description": "Return the smallest value from a list of numbers. Example: min_value(numbers=[5, 2, 9]) returns 2.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "numbers": {"type": "array", "items": NUM_SCHEMA},
+                "values": {"type": "array", "items": NUM_SCHEMA},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "max_value",
+        "description": "Return the largest value from a list of numbers. Example: max_value(numbers=[5, 2, 9]) returns 9.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "numbers": {"type": "array", "items": NUM_SCHEMA},
+                "values": {"type": "array", "items": NUM_SCHEMA},
+            },
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "convert_unit",
+        "description": "Convert between common units including temperature (°C, °F, K), length, weight, volume, speed, pressure, energy, power, time, area, illuminance, electrical units, storage sizes, and data rates. Example: convert_unit(value=22, from_unit='°C', to_unit='°F') returns 71.6 °F.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "value": NUM_SCHEMA,
+                "from_unit": STRING_SCHEMA,
+                "to_unit": STRING_SCHEMA,
+            },
+            "required": ["value", "from_unit", "to_unit"],
+            "additionalProperties": True,
+        },
+    },
+    {
+        "name": "evaluate_expression",
+        "description": "Safely evaluate a math expression with parentheses and operators such as +, -, *, /, %, //, and **. Also supports abs(), round(), min(), max(), sqrt(), ceil(), floor(), and constants pi, e, and tau. Example: evaluate_expression(expression='(68 - 32) * 5 / 9') returns 20.",
+        "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "expression": STRING_SCHEMA,
+            },
+            "required": ["expression"],
+            "additionalProperties": True,
+        },
+    },
+]
+
+
+UNIT_DISPLAY = {
+    "c": "°C",
+    "f": "°F",
+    "k": "K",
+    "mm": "mm",
+    "cm": "cm",
+    "m": "m",
+    "km": "km",
+    "in": "in",
+    "ft": "ft",
+    "yd": "yd",
+    "mi": "mi",
+    "mg": "mg",
+    "g": "g",
+    "kg": "kg",
+    "oz": "oz",
+    "lb": "lb",
+    "ml": "mL",
+    "l": "L",
+    "fl_oz": "fl oz",
+    "cup": "cup",
+    "pint": "pint",
+    "quart": "quart",
+    "gallon": "gal",
+    "m_s": "m/s",
+    "km_h": "km/h",
+    "mph": "mph",
+    "ft_s": "ft/s",
+    "knot": "knot",
+    "pa": "Pa",
+    "kpa": "kPa",
+    "hpa": "hPa",
+    "bar": "bar",
+    "psi": "psi",
+    "inhg": "inHg",
+    "j": "J",
+    "kj": "kJ",
+    "mj": "MJ",
+    "wh": "Wh",
+    "kwh": "kWh",
+    "w": "W",
+    "kw": "kW",
+    "mw": "MW",
+    "ms": "ms",
+    "s": "s",
+    "min": "min",
+    "h": "h",
+    "day": "day",
+    "week": "week",
+    "sq_cm": "cm²",
+    "sq_m": "m²",
+    "sq_km": "km²",
+    "sq_in": "in²",
+    "sq_ft": "ft²",
+    "sq_yd": "yd²",
+    "acre": "acre",
+    "hectare": "hectare",
+    "lx": "lx",
+    "fc": "fc",
+    "ma": "mA",
+    "a": "A",
+    "mv": "mV",
+    "v": "V",
+    "kv": "kV",
+    "hz": "Hz",
+    "khz": "kHz",
+    "mhz": "MHz",
+    "ghz": "GHz",
+    "b": "B",
+    "kb": "KB",
+    "mb": "MB",
+    "gb": "GB",
+    "tb": "TB",
+    "kib": "KiB",
+    "mib": "MiB",
+    "gib": "GiB",
+    "tib": "TiB",
+    "bps": "bps",
+    "kbps": "kbps",
+    "mbps": "Mbps",
+    "gbps": "Gbps",
+    "tbps": "Tbps",
+    "Bps": "B/s",
+    "KBps": "KB/s",
+    "MBps": "MB/s",
+    "GBps": "GB/s",
+    "TBps": "TB/s",
+    "KiBps": "KiB/s",
+    "MiBps": "MiB/s",
+    "GiBps": "GiB/s",
+    "TiBps": "TiB/s",
+}
+
+UNIT_GROUPS = {
+    "length": {
+        "mm": 0.001,
+        "cm": 0.01,
+        "m": 1.0,
+        "km": 1000.0,
+        "in": 0.0254,
+        "ft": 0.3048,
+        "yd": 0.9144,
+        "mi": 1609.344,
+    },
+    "mass": {
+        "mg": 0.001,
+        "g": 1.0,
+        "kg": 1000.0,
+        "oz": 28.349523125,
+        "lb": 453.59237,
+    },
+    "volume": {
+        "ml": 0.001,
+        "l": 1.0,
+        "fl_oz": 0.0295735295625,
+        "cup": 0.2365882365,
+        "pint": 0.473176473,
+        "quart": 0.946352946,
+        "gallon": 3.785411784,
+    },
+    "speed": {
+        "m_s": 1.0,
+        "km_h": 0.2777777777777778,
+        "mph": 0.44704,
+        "ft_s": 0.3048,
+        "knot": 0.5144444444444445,
+    },
+    "pressure": {
+        "pa": 1.0,
+        "kpa": 1000.0,
+        "hpa": 100.0,
+        "bar": 100000.0,
+        "psi": 6894.757293168,
+        "inhg": 3386.389,
+    },
+    "energy": {
+        "j": 1.0,
+        "kj": 1000.0,
+        "mj": 1000000.0,
+        "wh": 3600.0,
+        "kwh": 3600000.0,
+    },
+    "power": {
+        "w": 1.0,
+        "kw": 1000.0,
+        "mw": 1000000.0,
+    },
+    "time": {
+        "ms": 0.001,
+        "s": 1.0,
+        "min": 60.0,
+        "h": 3600.0,
+        "day": 86400.0,
+        "week": 604800.0,
+    },
+    "area": {
+        "sq_cm": 0.0001,
+        "sq_m": 1.0,
+        "sq_km": 1000000.0,
+        "sq_in": 0.00064516,
+        "sq_ft": 0.09290304,
+        "sq_yd": 0.83612736,
+        "acre": 4046.8564224,
+        "hectare": 10000.0,
+    },
+    "illuminance": {
+        "lx": 1.0,
+        "fc": 10.763910416709722,
+    },
+    "current": {
+        "ma": 0.001,
+        "a": 1.0,
+    },
+    "voltage": {
+        "mv": 0.001,
+        "v": 1.0,
+        "kv": 1000.0,
+    },
+    "frequency": {
+        "hz": 1.0,
+        "khz": 1000.0,
+        "mhz": 1000000.0,
+        "ghz": 1000000000.0,
+    },
+    "data_size": {
+        "b": 1.0,
+        "kb": 1000.0,
+        "mb": 1000000.0,
+        "gb": 1000000000.0,
+        "tb": 1000000000000.0,
+        "kib": 1024.0,
+        "mib": 1048576.0,
+        "gib": 1073741824.0,
+        "tib": 1099511627776.0,
+    },
+    "data_rate": {
+        "bps": 1.0,
+        "kbps": 1000.0,
+        "mbps": 1000000.0,
+        "gbps": 1000000000.0,
+        "tbps": 1000000000000.0,
+        "Bps": 8.0,
+        "KBps": 8000.0,
+        "MBps": 8000000.0,
+        "GBps": 8000000000.0,
+        "TBps": 8000000000000.0,
+        "KiBps": 8192.0,
+        "MiBps": 8388608.0,
+        "GiBps": 8589934592.0,
+        "TiBps": 8796093022208.0,
+    },
+}
+
+TEMPERATURE_UNITS = {"c", "f", "k"}
+UNIT_CATEGORY_BY_ID = {
+    unit_id: category
+    for category, units in UNIT_GROUPS.items()
+    for unit_id in units.keys()
+}
+for unit_id in TEMPERATURE_UNITS:
+    UNIT_CATEGORY_BY_ID[unit_id] = "temperature"
+
+UNIT_ALIASES: Dict[str, str] = {}
+CASE_SENSITIVE_UNIT_ALIASES: Dict[str, str] = {}
+
+
+def _normalize_case_sensitive_unit_alias(value: Any) -> str | None:
+    """Normalize a unit alias while preserving letter case for case-sensitive units."""
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    text = (
+        text.replace("μ", "u")
+        .replace("µ", "u")
+        .replace("º", "°")
+        .replace("²", "2")
+        .replace("³", "3")
+    )
+    text = text.replace("^2", "2").replace("^3", "3")
+    text = re.sub(r"\bsquared\b", "2", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bcubed\b", "3", text, flags=re.IGNORECASE)
+    text = text.replace("/", " per ")
+    text = text.replace("°", "")
+    text = re.sub(r"\bdegrees?\b", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"\bdeg\b", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"[^A-Za-z0-9]+", "", text)
+    return text or None
+
+
+def _normalize_unit_alias(value: Any) -> str | None:
+    """Normalize a unit alias for lookup."""
+    if value is None:
+        return None
+
+    text = str(value).strip().casefold()
+    if not text:
+        return None
+
+    text = (
+        text.replace("μ", "u")
+        .replace("µ", "u")
+        .replace("º", "°")
+        .replace("²", "2")
+        .replace("³", "3")
+    )
+    text = text.replace("^2", "2").replace("^3", "3")
+    text = re.sub(r"\bsquared\b", "2", text)
+    text = re.sub(r"\bcubed\b", "3", text)
+    text = text.replace("º", "°")
+    text = text.replace("/", " per ")
+    text = text.replace("°", "")
+    text = re.sub(r"\bdegrees?\b", "", text)
+    text = re.sub(r"\bdeg\b", "", text)
+    text = re.sub(r"[^a-z0-9]+", "", text)
+    return text or None
+
+
+def _register_unit_aliases(canonical: str, aliases: List[str]) -> None:
+    """Register unit aliases."""
+    for alias in aliases:
+        normalized = _normalize_unit_alias(alias)
+        if normalized:
+            UNIT_ALIASES[normalized] = canonical
+
+
+def _register_case_sensitive_unit_aliases(canonical: str, aliases: List[str]) -> None:
+    """Register aliases that need case-sensitive matching."""
+    for alias in aliases:
+        normalized = _normalize_case_sensitive_unit_alias(alias)
+        if normalized:
+            CASE_SENSITIVE_UNIT_ALIASES[normalized] = canonical
+
+
+_register_unit_aliases("c", ["c", "°c", "ºc", "celsius", "centigrade"])
+_register_unit_aliases("f", ["f", "°f", "ºf", "fahrenheit"])
+_register_unit_aliases("k", ["k", "kelvin"])
+_register_unit_aliases("mm", ["mm", "millimeter", "millimeters", "millimetre", "millimetres"])
+_register_unit_aliases("cm", ["cm", "centimeter", "centimeters", "centimetre", "centimetres"])
+_register_unit_aliases("m", ["m", "meter", "meters", "metre", "metres"])
+_register_unit_aliases("km", ["km", "kilometer", "kilometers", "kilometre", "kilometres"])
+_register_unit_aliases("in", ["in", "inch", "inches"])
+_register_unit_aliases("ft", ["ft", "foot", "feet"])
+_register_unit_aliases("yd", ["yd", "yard", "yards"])
+_register_unit_aliases("mi", ["mi", "mile", "miles"])
+_register_unit_aliases("mg", ["mg", "milligram", "milligrams"])
+_register_unit_aliases("g", ["g", "gram", "grams"])
+_register_unit_aliases("kg", ["kg", "kilogram", "kilograms"])
+_register_unit_aliases("oz", ["oz", "ounce", "ounces"])
+_register_unit_aliases("lb", ["lb", "lbs", "pound", "pounds"])
+_register_unit_aliases("ml", ["ml", "milliliter", "milliliters", "millilitre", "millilitres"])
+_register_unit_aliases("l", ["l", "liter", "liters", "litre", "litres"])
+_register_unit_aliases("fl_oz", ["fl oz", "floz", "fluid ounce", "fluid ounces"])
+_register_unit_aliases("cup", ["cup", "cups"])
+_register_unit_aliases("pint", ["pint", "pints", "pt"])
+_register_unit_aliases("quart", ["quart", "quarts", "qt"])
+_register_unit_aliases("gallon", ["gallon", "gallons", "gal"])
+_register_unit_aliases("m_s", ["m/s", "meter per second", "meters per second", "metre per second", "metres per second"])
+_register_unit_aliases("km_h", ["km/h", "kph", "kmh", "kilometer per hour", "kilometers per hour", "kilometre per hour", "kilometres per hour"])
+_register_unit_aliases("mph", ["mph", "mile per hour", "miles per hour"])
+_register_unit_aliases("ft_s", ["ft/s", "fps", "foot per second", "feet per second"])
+_register_unit_aliases("knot", ["knot", "knots", "kt", "kts"])
+_register_unit_aliases("pa", ["pa", "pascal", "pascals"])
+_register_unit_aliases("kpa", ["kpa", "kilopascal", "kilopascals"])
+_register_unit_aliases("hpa", ["hpa", "hectopascal", "hectopascals", "mbar", "millibar", "millibars"])
+_register_unit_aliases("bar", ["bar", "bars"])
+_register_unit_aliases("psi", ["psi"])
+_register_unit_aliases("inhg", ["inhg", "in hg", "inch mercury", "inches mercury", "inch of mercury", "inches of mercury"])
+_register_unit_aliases("j", ["j", "joule", "joules"])
+_register_unit_aliases("kj", ["kj", "kilojoule", "kilojoules"])
+_register_unit_aliases("mj", ["mj", "megajoule", "megajoules"])
+_register_unit_aliases("wh", ["wh", "watt hour", "watt hours"])
+_register_unit_aliases("kwh", ["kwh", "kilowatt hour", "kilowatt hours"])
+_register_unit_aliases("w", ["w", "watt", "watts"])
+_register_unit_aliases("kw", ["kw", "kilowatt", "kilowatts"])
+_register_unit_aliases("mw", ["mw", "megawatt", "megawatts"])
+_register_unit_aliases("ms", ["ms", "millisecond", "milliseconds"])
+_register_unit_aliases("s", ["s", "sec", "secs", "second", "seconds"])
+_register_unit_aliases("min", ["min", "mins", "minute", "minutes"])
+_register_unit_aliases("h", ["h", "hr", "hrs", "hour", "hours"])
+_register_unit_aliases("day", ["day", "days", "d"])
+_register_unit_aliases("week", ["week", "weeks", "wk", "wks"])
+_register_unit_aliases("sq_cm", ["cm2", "cm²", "square centimeter", "square centimeters", "square centimetre", "square centimetres"])
+_register_unit_aliases("sq_m", ["m2", "m²", "sqm", "square meter", "square meters", "square metre", "square metres"])
+_register_unit_aliases("sq_km", ["km2", "km²", "square kilometer", "square kilometers", "square kilometre", "square kilometres"])
+_register_unit_aliases("sq_in", ["in2", "in²", "square inch", "square inches", "sqin", "sq in"])
+_register_unit_aliases("sq_ft", ["ft2", "ft²", "sqft", "sq ft", "square foot", "square feet"])
+_register_unit_aliases("sq_yd", ["yd2", "yd²", "sqyd", "sq yd", "square yard", "square yards"])
+_register_unit_aliases("acre", ["acre", "acres"])
+_register_unit_aliases("hectare", ["hectare", "hectares", "ha"])
+_register_unit_aliases("lx", ["lx", "lux"])
+_register_unit_aliases("fc", ["fc", "foot candle", "foot candles", "footcandle", "footcandles"])
+_register_unit_aliases("ma", ["ma", "milliamp", "milliamps", "milliampere", "milliamperes"])
+_register_unit_aliases("a", ["a", "amp", "amps", "ampere", "amperes"])
+_register_unit_aliases("mv", ["mv", "millivolt", "millivolts"])
+_register_unit_aliases("v", ["v", "volt", "volts"])
+_register_unit_aliases("kv", ["kv", "kilovolt", "kilovolts"])
+_register_unit_aliases("hz", ["hz", "hertz"])
+_register_unit_aliases("khz", ["khz", "kilohertz"])
+_register_unit_aliases("mhz", ["mhz", "megahertz"])
+_register_unit_aliases("ghz", ["ghz", "gigahertz"])
+_register_unit_aliases("b", ["b", "byte", "bytes"])
+_register_unit_aliases("kb", ["kb", "kilobyte", "kilobytes"])
+_register_unit_aliases("mb", ["mb", "megabyte", "megabytes"])
+_register_unit_aliases("gb", ["gb", "gigabyte", "gigabytes"])
+_register_unit_aliases("tb", ["tb", "terabyte", "terabytes"])
+_register_unit_aliases("kib", ["kib", "kibibyte", "kibibytes", "kib"])
+_register_unit_aliases("mib", ["mib", "mebibyte", "mebibytes"])
+_register_unit_aliases("gib", ["gib", "gibibyte", "gibibytes"])
+_register_unit_aliases("tib", ["tib", "tebibyte", "tebibytes"])
+_register_unit_aliases("bps", ["bps", "bit per second", "bits per second"])
+_register_unit_aliases("kbps", ["kbps", "kilobit per second", "kilobits per second"])
+_register_unit_aliases("mbps", ["mbps", "megabit per second", "megabits per second"])
+_register_unit_aliases("gbps", ["gbps", "gigabit per second", "gigabits per second"])
+_register_unit_aliases("tbps", ["tbps", "terabit per second", "terabits per second"])
+_register_unit_aliases("Bps", ["byte per second", "bytes per second"])
+_register_unit_aliases("KBps", ["kilobyte per second", "kilobytes per second"])
+_register_unit_aliases("MBps", ["megabyte per second", "megabytes per second"])
+_register_unit_aliases("GBps", ["gigabyte per second", "gigabytes per second"])
+_register_unit_aliases("TBps", ["terabyte per second", "terabytes per second"])
+_register_unit_aliases("KiBps", ["kibibyte per second", "kibibytes per second"])
+_register_unit_aliases("MiBps", ["mebibyte per second", "mebibytes per second"])
+_register_unit_aliases("GiBps", ["gibibyte per second", "gibibytes per second"])
+_register_unit_aliases("TiBps", ["tebibyte per second", "tebibytes per second"])
+
+_register_case_sensitive_unit_aliases("bps", ["b/s"])
+_register_case_sensitive_unit_aliases("kbps", ["kb/s", "Kb/s"])
+_register_case_sensitive_unit_aliases("mbps", ["mb/s", "Mb/s"])
+_register_case_sensitive_unit_aliases("gbps", ["gb/s", "Gb/s"])
+_register_case_sensitive_unit_aliases("tbps", ["tb/s", "Tb/s"])
+_register_case_sensitive_unit_aliases("Bps", ["B/s", "Bps"])
+_register_case_sensitive_unit_aliases("KBps", ["KB/s", "KBps", "kB/s", "kBps"])
+_register_case_sensitive_unit_aliases("MBps", ["MB/s", "MBps"])
+_register_case_sensitive_unit_aliases("GBps", ["GB/s", "GBps"])
+_register_case_sensitive_unit_aliases("TBps", ["TB/s", "TBps"])
+_register_case_sensitive_unit_aliases("KiBps", ["KiB/s", "KiBps"])
+_register_case_sensitive_unit_aliases("MiBps", ["MiB/s", "MiBps"])
+_register_case_sensitive_unit_aliases("GiBps", ["GiB/s", "GiBps"])
+_register_case_sensitive_unit_aliases("TiBps", ["TiB/s", "TiBps"])
+
+
+ALLOWED_AST_BINARY_OPERATORS = {
+    ast.Add: lambda left, right: left + right,
+    ast.Sub: lambda left, right: left - right,
+    ast.Mult: lambda left, right: left * right,
+    ast.Div: lambda left, right: left / right,
+    ast.FloorDiv: lambda left, right: left // right,
+    ast.Mod: lambda left, right: left % right,
+}
+
+ALLOWED_AST_UNARY_OPERATORS = {
+    ast.UAdd: lambda value: value,
+    ast.USub: lambda value: -value,
+}
+
+ALLOWED_AST_FUNCTIONS = {
+    "abs": abs,
+    "round": round,
+    "min": min,
+    "max": max,
+    "sqrt": math.sqrt,
+    "ceil": math.ceil,
+    "floor": math.floor,
+}
+
+ALLOWED_AST_NAMES = {
+    "pi": math.pi,
+    "e": math.e,
+    "tau": math.tau,
+}
+
+
+class CalculatorTool:
+    """Calculator toolset with arithmetic, summary, and unit conversion tools."""
+
+    def __init__(self, hass) -> None:
+        """Initialize calculator tools."""
+        self.hass = hass
+        self._tool_names = {tool["name"] for tool in CALCULATOR_TOOLS}
+
+    async def initialize(self) -> None:
+        """Initialize calculator tools."""
+        return None
+
+    def handles_tool(self, tool_name: str) -> bool:
+        """Check if this class handles the given tool."""
+        return tool_name in self._tool_names
+
+    def get_tool_definitions(self) -> List[Dict[str, Any]]:
+        """Get MCP tool definitions for calculator tools."""
+        return [
+            {
+                **tool_definition,
+                "llmDescription": CALCULATOR_LLM_DESCRIPTIONS.get(
+                    tool_definition["name"], tool_definition["description"]
+                ),
+            }
+            for tool_definition in CALCULATOR_TOOLS
+        ]
+
+    async def handle_call(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Execute a calculator tool."""
+        result = self._execute(tool_name, arguments or {})
+        is_error = isinstance(result, str) and result.startswith("Error:")
+
+        return {
+            "content": [{"type": "text", "text": result}],
+            "isError": is_error,
+        }
+
+    def _extract_numbers(self, value: Any) -> List[float]:
+        """Extract numeric values from a tolerant value shape."""
+        numbers: List[float] = []
+        self._collect_numbers(value, numbers)
+        return numbers
+
+    def _extract_numbers_from_keys(
+        self, arguments: Dict[str, Any], keys: List[str]
+    ) -> List[float]:
+        """Extract numeric values only from specific argument keys."""
+        numbers: List[float] = []
+        for key in keys:
+            if key in arguments:
+                self._collect_numbers(arguments.get(key), numbers)
+        return numbers
+
+    def _collect_numbers(self, value: Any, numbers: List[float]) -> None:
+        """Collect numbers from nested argument values."""
+        parsed = self._coerce_number(value)
+        if parsed is not None:
+            numbers.append(parsed)
+            return
+
+        if isinstance(value, dict):
+            for item in value.values():
+                self._collect_numbers(item, numbers)
+            return
+
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                self._collect_numbers(item, numbers)
+
+    def _coerce_number(self, value: Any) -> float | int | None:
+        """Coerce a value into a number when possible."""
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)):
+            if not math.isfinite(value):
+                return None
+            return value
+        if isinstance(value, str):
+            text = value.strip().replace(",", "").replace("_", "")
+            if not text:
+                return None
+            try:
+                parsed = float(text)
+            except ValueError:
+                return None
+            if not math.isfinite(parsed):
+                return None
+            if parsed.is_integer():
+                return int(parsed)
+            return parsed
+        return None
+
+    def _normalize_result(self, result: float | int) -> str:
+        """Normalize numeric results into compact text."""
+        if isinstance(result, float):
+            if not math.isfinite(result):
+                return str(result)
+            if result == 0:
+                result = 0.0
+            if result.is_integer():
+                return str(int(result))
+            return format(result, ".12g")
+        return str(result)
+
+    def _get_number(
+        self,
+        arguments: Dict[str, Any],
+        keys: List[str],
+    ) -> float | int | None:
+        """Get the first matching numeric value from preferred keys."""
+        for key in keys:
+            if key not in arguments:
+                continue
+            parsed = self._coerce_number(arguments.get(key))
+            if parsed is not None:
+                return parsed
+        return None
+
+    def _coerce_integer(self, value: Any) -> int | None:
+        """Coerce a value into an integer when possible."""
+        parsed = self._coerce_number(value)
+        if parsed is None:
+            return None
+        if isinstance(parsed, float) and not parsed.is_integer():
+            return None
+        return int(parsed)
+
+    def _get_first_text(
+        self, arguments: Dict[str, Any], keys: List[str]
+    ) -> str | None:
+        """Get the first non-empty text value from preferred keys."""
+        for key in keys:
+            value = arguments.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                return text
+        return None
+
+    def _has_collection_operand(self, arguments: Dict[str, Any]) -> bool:
+        """Check if the call provided list-like operands instead of named a/b args."""
+        for key in ("numbers", "operands", "values", "args"):
+            value = arguments.get(key)
+            if isinstance(value, (list, tuple, set)):
+                return True
+        return False
+
+    def _require_numbers(self, numbers: List[float], tool_name: str) -> str | None:
+        """Validate that a list-based tool received at least one number."""
+        if numbers:
+            return None
+        return f"Error: {tool_name} requires one or more numbers"
+
+    def _require_number(
+        self, arguments: Dict[str, Any], keys: List[str], label: str, tool_name: str
+    ) -> float | int | str:
+        """Require a named numeric argument."""
+        value = self._get_number(arguments, keys)
+        if value is None:
+            return f"Error: {tool_name} requires {label}"
+        return value
+
+    def _normalize_unit(self, value: Any) -> str | None:
+        """Normalize a unit name into a canonical internal unit id."""
+        case_sensitive_normalized = _normalize_case_sensitive_unit_alias(value)
+        if case_sensitive_normalized:
+            case_sensitive_match = CASE_SENSITIVE_UNIT_ALIASES.get(case_sensitive_normalized)
+            if case_sensitive_match:
+                return case_sensitive_match
+
+        normalized = _normalize_unit_alias(value)
+        if not normalized:
+            return None
+        return UNIT_ALIASES.get(normalized)
+
+    def _convert_temperature(self, value: float, from_unit: str, to_unit: str) -> float:
+        """Convert temperatures through Celsius."""
+        if from_unit == to_unit:
+            return value
+
+        if from_unit == "c":
+            celsius = value
+        elif from_unit == "f":
+            celsius = (value - 32.0) * 5.0 / 9.0
+        elif from_unit == "k":
+            celsius = value - 273.15
+        else:
+            raise ValueError(f"Unsupported temperature unit '{from_unit}'")
+
+        if to_unit == "c":
+            return celsius
+        if to_unit == "f":
+            return celsius * 9.0 / 5.0 + 32.0
+        if to_unit == "k":
+            return celsius + 273.15
+
+        raise ValueError(f"Unsupported temperature unit '{to_unit}'")
+
+    def _convert_linear_unit(self, value: float, from_unit: str, to_unit: str) -> float:
+        """Convert units using a linear factor table."""
+        category = UNIT_CATEGORY_BY_ID.get(from_unit)
+        if category is None or category != UNIT_CATEGORY_BY_ID.get(to_unit):
+            raise ValueError(f"Cannot convert {from_unit} to {to_unit}")
+
+        factors = UNIT_GROUPS.get(category)
+        if factors is None:
+            raise ValueError(f"No conversion table for category '{category}'")
+
+        base_value = value * factors[from_unit]
+        return base_value / factors[to_unit]
+
+    def _convert_unit(self, value: float, from_unit_raw: Any, to_unit_raw: Any) -> str:
+        """Convert between supported units."""
+        from_unit = self._normalize_unit(from_unit_raw)
+        to_unit = self._normalize_unit(to_unit_raw)
+
+        if not from_unit:
+            return f"Error: unsupported from_unit '{from_unit_raw}'"
+        if not to_unit:
+            return f"Error: unsupported to_unit '{to_unit_raw}'"
+
+        from_category = UNIT_CATEGORY_BY_ID.get(from_unit)
+        to_category = UNIT_CATEGORY_BY_ID.get(to_unit)
+        if from_category != to_category:
+            return (
+                f"Error: cannot convert {UNIT_DISPLAY.get(from_unit, from_unit)} to "
+                f"{UNIT_DISPLAY.get(to_unit, to_unit)}"
+            )
+
+        try:
+            if from_category == "temperature":
+                converted = self._convert_temperature(value, from_unit, to_unit)
+            else:
+                converted = self._convert_linear_unit(value, from_unit, to_unit)
+        except Exception as err:
+            return f"Error: {err}"
+
+        if not math.isfinite(converted):
+            return "Error: conversion result is not finite"
+
+        return f"{self._normalize_result(converted)} {UNIT_DISPLAY.get(to_unit, to_unit)}"
+
+    def _safe_power(self, left: float | int, right: float | int) -> float | int:
+        """Limit pathological exponent operations in expression evaluation."""
+        if abs(right) > 1000:
+            raise ValueError("exponent is too large")
+        if abs(left) > 1000000 and abs(right) > 20:
+            raise ValueError("power expression is too large")
+        if right > 1 and abs(left) > 1:
+            estimated_bits = abs(right) * math.log2(abs(left))
+            if estimated_bits > 4096:
+                raise ValueError("expression result is too large")
+
+        result = left**right
+        if isinstance(result, complex):
+            raise ValueError("complex results are not supported")
+        if isinstance(result, int) and result.bit_length() > 4096:
+            raise ValueError("expression result is too large")
+        if isinstance(result, float) and not math.isfinite(result):
+            raise ValueError("expression result is not finite")
+        return result
+
+    def _evaluate_expression_node(self, node: ast.AST) -> float | int:
+        """Safely evaluate an AST node for arithmetic expressions."""
+        if isinstance(node, ast.Expression):
+            return self._evaluate_expression_node(node.body)
+
+        if isinstance(node, ast.Constant):
+            value = node.value
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("expression may only contain numeric constants")
+            return value
+
+        if type(node).__name__ == "Num":  # pragma: no cover - compat for older Python ASTs
+            return node.n
+
+        if isinstance(node, ast.BinOp):
+            if isinstance(node.op, ast.Pow):
+                left = self._evaluate_expression_node(node.left)
+                right = self._evaluate_expression_node(node.right)
+                return self._safe_power(left, right)
+
+            operator = ALLOWED_AST_BINARY_OPERATORS.get(type(node.op))
+            if operator is None:
+                raise ValueError("expression contains an unsupported operator")
+            left = self._evaluate_expression_node(node.left)
+            right = self._evaluate_expression_node(node.right)
+            return operator(left, right)
+
+        if isinstance(node, ast.UnaryOp):
+            operator = ALLOWED_AST_UNARY_OPERATORS.get(type(node.op))
+            if operator is None:
+                raise ValueError("expression contains an unsupported unary operator")
+            return operator(self._evaluate_expression_node(node.operand))
+
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name):
+                raise ValueError("expression contains an unsupported function call")
+            function = ALLOWED_AST_FUNCTIONS.get(node.func.id)
+            if function is None:
+                raise ValueError(f"function '{node.func.id}' is not supported")
+            if node.keywords:
+                raise ValueError("keyword arguments are not supported in expressions")
+            return function(*[self._evaluate_expression_node(node_arg) for node_arg in node.args])
+
+        if isinstance(node, ast.Name):
+            if node.id in ALLOWED_AST_NAMES:
+                return ALLOWED_AST_NAMES[node.id]
+            raise ValueError(f"name '{node.id}' is not supported")
+
+        raise ValueError("expression contains unsupported syntax")
+
+    def _evaluate_expression(self, expression_raw: Any) -> str:
+        """Safely evaluate a user-provided arithmetic expression."""
+        if expression_raw is None:
+            return "Error: evaluate_expression requires an expression"
+
+        expression = str(expression_raw).strip()
+        if not expression:
+            return "Error: evaluate_expression requires a non-empty expression"
+        if len(expression) > 256:
+            return "Error: expression is too long"
+
+        expression = (
+            expression.replace("×", "*")
+            .replace("÷", "/")
+            .replace("−", "-")
+            .replace("^", "**")
+        )
+        expression = re.sub(r"(?<=\d),(?=\d)", "", expression)
+
+        try:
+            parsed = ast.parse(expression, mode="eval")
+            if sum(1 for _ in ast.walk(parsed)) > 128:
+                return "Error: expression is too complex"
+            result = self._evaluate_expression_node(parsed)
+        except ZeroDivisionError:
+            return "Error: division by zero"
+        except Exception as err:
+            return f"Error: {err}"
+
+        return self._normalize_result(result)
+
+    def _execute(self, tool_name: str, arguments: Dict[str, Any]) -> str:
+        """Execute a calculator operation."""
+        pair_number_keys = [
+            "a",
+            "b",
+            "x",
+            "y",
+            "value",
+            "number",
+            "base",
+            "exponent",
+            "first",
+            "second",
+            "first_number",
+            "second_number",
+        ]
+        collection_number_keys = ["numbers", "values", "operands", "args"]
+
+        try:
+            if tool_name == "add":
+                if self._has_collection_operand(arguments):
+                    numbers = self._extract_numbers_from_keys(arguments, collection_number_keys)
+                    error = self._require_numbers(numbers, tool_name)
+                    if error:
+                        return error
+                    result = math.fsum(numbers)
+                else:
+                    a = self._require_number(
+                        arguments,
+                        ["a", "x", "value", "number", "first", "first_number"],
+                        "a",
+                        tool_name,
+                    )
+                    if isinstance(a, str):
+                        return a
+                    b = self._require_number(
+                        arguments,
+                        ["b", "y", "second", "second_number"],
+                        "b",
+                        tool_name,
+                    )
+                    if isinstance(b, str):
+                        return b
+                    result = a + b
+            elif tool_name == "subtract":
+                a = self._require_number(
+                    arguments,
+                    ["a", "x", "value", "number", "first", "first_number"],
+                    "a",
+                    tool_name,
+                )
+                if isinstance(a, str):
+                    return a
+                b = self._require_number(
+                    arguments,
+                    ["b", "y", "second", "second_number"],
+                    "b",
+                    tool_name,
+                )
+                if isinstance(b, str):
+                    return b
+                result = a - b
+            elif tool_name == "multiply":
+                if self._has_collection_operand(arguments):
+                    numbers = self._extract_numbers_from_keys(arguments, collection_number_keys)
+                    error = self._require_numbers(numbers, tool_name)
+                    if error:
+                        return error
+                    result = 1.0
+                    for value in numbers:
+                        result *= value
+                else:
+                    a = self._require_number(
+                        arguments,
+                        ["a", "x", "value", "number", "first", "first_number"],
+                        "a",
+                        tool_name,
+                    )
+                    if isinstance(a, str):
+                        return a
+                    b = self._require_number(
+                        arguments,
+                        ["b", "y", "second", "second_number"],
+                        "b",
+                        tool_name,
+                    )
+                    if isinstance(b, str):
+                        return b
+                    result = a * b
+            elif tool_name == "divide":
+                a = self._require_number(
+                    arguments,
+                    ["a", "x", "value", "number", "first", "first_number"],
+                    "a",
+                    tool_name,
+                )
+                if isinstance(a, str):
+                    return a
+                b = self._require_number(
+                    arguments,
+                    ["b", "y", "second", "second_number"],
+                    "b",
+                    tool_name,
+                )
+                if isinstance(b, str):
+                    return b
+                if b == 0:
+                    return "Error: division by zero"
+                result = a / b
+            elif tool_name == "sqrt":
+                a = self._require_number(
+                    arguments,
+                    ["a", "value", "number", "x"],
+                    "a",
+                    tool_name,
+                )
+                if isinstance(a, str):
+                    return a
+                if a < 0:
+                    return "Error: square root requires a non-negative number"
+                result = math.sqrt(a)
+            elif tool_name == "power":
+                a = self._require_number(
+                    arguments,
+                    ["a", "x", "value", "number", "base", "first", "first_number"],
+                    "a",
+                    tool_name,
+                )
+                if isinstance(a, str):
+                    return a
+                b = self._require_number(
+                    arguments,
+                    ["b", "y", "exponent", "second", "second_number"],
+                    "b",
+                    tool_name,
+                )
+                if isinstance(b, str):
+                    return b
+                try:
+                    result = self._safe_power(a, b)
+                except ValueError as err:
+                    return f"Error: {err}"
+            elif tool_name == "round_number":
+                a = self._require_number(
+                    arguments,
+                    ["a", "value", "number", "x"],
+                    "a",
+                    tool_name,
+                )
+                if isinstance(a, str):
+                    return a
+                decimals = 0
+                for key in ["decimals", "n", "digits", "places"]:
+                    if key not in arguments:
+                        continue
+                    parsed = self._coerce_integer(arguments.get(key))
+                    if parsed is None:
+                        return "Error: round_number requires an integer decimals value"
+                    decimals = parsed
+                    break
+                result = round(a, decimals)
+            elif tool_name == "average":
+                numbers = self._extract_numbers_from_keys(arguments, collection_number_keys)
+                if not numbers:
+                    numbers = self._extract_numbers_from_keys(arguments, pair_number_keys)
+                error = self._require_numbers(numbers, tool_name)
+                if error:
+                    return error
+                result = math.fsum(numbers) / len(numbers)
+            elif tool_name == "min_value":
+                numbers = self._extract_numbers_from_keys(arguments, collection_number_keys)
+                if not numbers:
+                    numbers = self._extract_numbers_from_keys(arguments, pair_number_keys)
+                error = self._require_numbers(numbers, tool_name)
+                if error:
+                    return error
+                result = min(numbers)
+            elif tool_name == "max_value":
+                numbers = self._extract_numbers_from_keys(arguments, collection_number_keys)
+                if not numbers:
+                    numbers = self._extract_numbers_from_keys(arguments, pair_number_keys)
+                error = self._require_numbers(numbers, tool_name)
+                if error:
+                    return error
+                result = max(numbers)
+            elif tool_name == "convert_unit":
+                value = self._require_number(
+                    arguments,
+                    ["value", "a", "number", "x"],
+                    "value",
+                    tool_name,
+                )
+                if isinstance(value, str):
+                    return value
+                from_unit = self._get_first_text(
+                    arguments,
+                    ["from_unit", "from", "source_unit", "unit_from"],
+                )
+                to_unit = self._get_first_text(
+                    arguments,
+                    ["to_unit", "to", "target_unit", "unit_to"],
+                )
+                if not from_unit or not to_unit:
+                    return "Error: convert_unit requires from_unit and to_unit"
+                return self._convert_unit(float(value), from_unit, to_unit)
+            elif tool_name == "evaluate_expression":
+                expression = self._get_first_text(
+                    arguments,
+                    ["expression", "expr", "formula"],
+                )
+                return self._evaluate_expression(expression)
+            else:
+                return f"Error: unknown tool '{tool_name}'"
+        except Exception as err:
+            _LOGGER.exception("Calculator tool '%s' failed", tool_name)
+            return f"Error: {err}"
+
+        return self._normalize_result(result)

--- a/custom_components/mcp_assist/custom_tools/external_loader.py
+++ b/custom_components/mcp_assist/custom_tools/external_loader.py
@@ -1,0 +1,840 @@
+"""Loader for manifest-based MCP Assist tool packages."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import importlib.util
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..const import (
+    CUSTOM_TOOL_MANIFEST_FILENAME,
+    CUSTOM_TOOL_SCHEMA_VERSION,
+    CUSTOM_TOOL_SETTINGS_DIRECTORY,
+    CUSTOM_TOOLS_DIRECTORY,
+)
+from ..custom_tool_api import MCPAssistCustomToolManifest, MCPAssistExternalTool
+from .schema_utils import SchemaValidationError, validate_and_normalize_json_value
+
+_LOGGER = logging.getLogger(__name__)
+
+_TOOL_ID_PATTERN = re.compile(r"^[a-z0-9_]+$")
+_TOOL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+_MAX_PROMPT_CHARS_PER_TOOL = 220
+_MAX_PROMPT_CHARS_TOTAL = 2200
+
+
+@dataclass
+class LoadedToolPackage:
+    """Loaded and validated MCP Assist tool package."""
+
+    manifest: MCPAssistCustomToolManifest
+    instance: MCPAssistExternalTool
+    tool_definitions: tuple[dict[str, Any], ...]
+    tool_names: tuple[str, ...]
+    prompt_instructions: str
+    settings_schema: dict[str, Any]
+    shared_settings: dict[str, Any]
+    shared_settings_path: str | None
+
+
+LoadedExternalTool = LoadedToolPackage
+
+
+class ExternalCustomToolLoader:
+    """Load manifest-based tool packages from a configured root directory."""
+
+    def __init__(
+        self,
+        hass,
+        *,
+        tools_root: Path | None = None,
+        settings_root: Path | None = None,
+        module_namespace: str = "mcp_assist_external_tools",
+        require_tool_name_prefix: bool = True,
+        package_log_label: str = "external custom tool package",
+        prompt_package_label: str = "Custom tool package",
+        prompt_chars_per_tool: int = _MAX_PROMPT_CHARS_PER_TOOL,
+    ) -> None:
+        """Initialize the loader."""
+        self.hass = hass
+        self._tools_root = tools_root
+        self._settings_root = settings_root
+        self._module_namespace = module_namespace
+        self._require_tool_name_prefix = require_tool_name_prefix
+        self._package_log_label = package_log_label
+        self._prompt_package_label = prompt_package_label
+        self._prompt_chars_per_tool = prompt_chars_per_tool
+        self.last_load_errors: list[dict[str, str]] = []
+        self.last_tools_root: Path = self.get_tools_root()
+        self.last_scanned_packages: tuple[str, ...] = ()
+        self.last_loaded_at: str = ""
+
+    def get_tools_root(self) -> Path:
+        """Return the package root directory for this loader."""
+        if self._tools_root is not None:
+            return self._tools_root
+        return Path(self.hass.config.path(CUSTOM_TOOLS_DIRECTORY))
+
+    def get_settings_root(self) -> Path:
+        """Return the package-settings directory for this loader."""
+        if self._settings_root is not None:
+            return self._settings_root
+        return Path(self.hass.config.path(CUSTOM_TOOL_SETTINGS_DIRECTORY))
+
+    async def load(
+        self,
+        *,
+        reserved_tool_names: set[str] | None = None,
+        reserved_tool_ids: set[str] | None = None,
+        allowed_tool_ids: set[str] | None = None,
+    ) -> list[LoadedToolPackage]:
+        """Load and validate all matching tool packages."""
+        reserved = set(reserved_tool_names or set())
+        reserved_ids = set(reserved_tool_ids or set())
+        seen_tool_ids: set[str] = set()
+        tools_root = self.get_tools_root()
+        self.last_tools_root = tools_root
+        self.last_load_errors = []
+        self.last_loaded_at = datetime.now(timezone.utc).isoformat()
+        if not await self.hass.async_add_executor_job(tools_root.exists):
+            _LOGGER.info(
+                "External custom tools enabled, but %s does not exist yet.",
+                tools_root,
+            )
+            self.last_scanned_packages = ()
+            return []
+
+        if not await self.hass.async_add_executor_job(tools_root.is_dir):
+            _LOGGER.warning(
+                "External custom tools path %s exists but is not a directory. Skipping.",
+                tools_root,
+            )
+            self.last_scanned_packages = ()
+            return []
+
+        loaded: list[LoadedToolPackage] = []
+        package_dirs = await self.hass.async_add_executor_job(
+            self._discover_package_dirs,
+            tools_root,
+        )
+        self.last_scanned_packages = tuple(
+            tool_dir.name for tool_dir, _is_symlink in package_dirs
+        )
+        for tool_dir, is_symlink in package_dirs:
+            if allowed_tool_ids is not None and tool_dir.name not in allowed_tool_ids:
+                continue
+
+            if is_symlink:
+                _LOGGER.warning(
+                    "Skipping %s %s because symlinked directories are not allowed.",
+                    self._package_log_label,
+                    tool_dir,
+                )
+                self.last_load_errors.append(
+                    {"tool_dir": tool_dir.name, "error": "Symlinked package directories are not allowed"}
+                )
+                continue
+
+            tool: MCPAssistExternalTool | None = None
+            try:
+                manifest = await self._load_manifest(tool_dir)
+                if manifest.tool_id in reserved_ids or manifest.tool_id in seen_tool_ids:
+                    raise ValueError(
+                        f"Manifest id {manifest.tool_id!r} conflicts with an existing tool package"
+                    )
+                tool = self._instantiate_tool(tool_dir, manifest)
+                settings_schema = self._normalize_settings_schema(
+                    manifest,
+                    tool.get_settings_schema(),
+                )
+                shared_settings, shared_settings_path = await self._load_shared_settings(
+                    manifest,
+                    settings_schema,
+                )
+                tool._set_loaded_settings(shared_settings)
+                await tool.initialize()
+                tool_definitions = self._normalize_tool_definitions(
+                    manifest,
+                    tool.get_tool_definitions(),
+                    reserved_tool_names=reserved,
+                )
+                tool_names = tuple(
+                    str(tool_definition["name"]) for tool_definition in tool_definitions
+                )
+                reserved.update(tool_names)
+                prompt_instructions = await self._build_prompt_instructions(
+                    tool_dir,
+                    manifest,
+                    tool,
+                    tool_names,
+                )
+                loaded.append(
+                    LoadedToolPackage(
+                        manifest=manifest,
+                        instance=tool,
+                        tool_definitions=tuple(tool_definitions),
+                        tool_names=tool_names,
+                        prompt_instructions=prompt_instructions,
+                        settings_schema=settings_schema,
+                        shared_settings=shared_settings,
+                        shared_settings_path=shared_settings_path,
+                    )
+                )
+                seen_tool_ids.add(manifest.tool_id)
+                _LOGGER.info(
+                    "Loaded %s %s with %d tool(s)",
+                    self._package_log_label,
+                    manifest.tool_id,
+                    len(tool_names),
+                )
+            except Exception as err:
+                if tool is not None:
+                    try:
+                        await tool.async_shutdown()
+                    except Exception as shutdown_err:
+                        _LOGGER.debug(
+                            "%s %s also failed during cleanup: %s",
+                            self._package_log_label,
+                            getattr(getattr(tool, "manifest", None), "tool_id", tool_dir.name),
+                            shutdown_err,
+                        )
+                _LOGGER.error(
+                    "Failed to load %s from %s: %s",
+                    self._package_log_label,
+                    tool_dir,
+                    err,
+                )
+                self.last_load_errors.append(
+                    {"tool_dir": tool_dir.name, "error": str(err)}
+                )
+
+        return loaded
+
+    def _discover_package_dirs(self, tools_root: Path) -> list[tuple[Path, bool]]:
+        """Return sorted candidate package directories and whether they are symlinks."""
+        return [
+            (tool_dir, tool_dir.is_symlink())
+            for tool_dir in sorted(
+                tools_root.iterdir(),
+                key=lambda item: item.name.casefold(),
+            )
+            if tool_dir.is_dir() and not tool_dir.name.startswith((".", "__"))
+        ]
+
+    async def _load_manifest(self, tool_dir: Path) -> MCPAssistCustomToolManifest:
+        """Load and validate a custom tool manifest without blocking the event loop."""
+        return await self.hass.async_add_executor_job(
+            self._load_manifest_from_disk,
+            tool_dir,
+        )
+
+    def _load_manifest_from_disk(self, tool_dir: Path) -> MCPAssistCustomToolManifest:
+        """Load and validate a custom tool manifest."""
+        manifest_path = tool_dir / CUSTOM_TOOL_MANIFEST_FILENAME
+        if not manifest_path.is_file():
+            raise ValueError(f"{CUSTOM_TOOL_MANIFEST_FILENAME} is required")
+
+        try:
+            raw_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception as err:
+            raise ValueError(f"Invalid {manifest_path.name}: {err}") from err
+
+        if not isinstance(raw_manifest, dict):
+            raise ValueError(f"{manifest_path.name} must contain an object")
+
+        schema_version = raw_manifest.get("schema_version")
+        if schema_version != CUSTOM_TOOL_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported schema_version {schema_version!r}; expected {CUSTOM_TOOL_SCHEMA_VERSION}"
+            )
+
+        tool_id = str(raw_manifest.get("id") or "").strip()
+        if not _TOOL_ID_PATTERN.match(tool_id):
+            raise ValueError(
+                "manifest id must contain only lowercase letters, numbers, and underscores"
+            )
+        if tool_dir.name != tool_id:
+            raise ValueError(
+                f"tool directory name must match manifest id ({tool_id!r})"
+            )
+
+        name = str(raw_manifest.get("name") or "").strip()
+        description = str(raw_manifest.get("description") or "").strip()
+        version = str(raw_manifest.get("version") or "").strip()
+        entrypoint = str(raw_manifest.get("entrypoint") or "").strip()
+
+        if not name:
+            raise ValueError("manifest name is required")
+        if not description:
+            raise ValueError("manifest description is required")
+        if not version:
+            raise ValueError("manifest version is required")
+        if ":" not in entrypoint:
+            raise ValueError("entrypoint must be in 'module:ClassName' format")
+
+        raw_capabilities = raw_manifest.get("capabilities") or []
+        if not isinstance(raw_capabilities, list):
+            raise ValueError("manifest capabilities must be a list of strings")
+        capabilities = tuple(
+            str(item).strip()
+            for item in raw_capabilities
+            if str(item).strip()
+        )
+
+        prompt_append_file = raw_manifest.get("prompt_append_file")
+        if prompt_append_file is not None:
+            prompt_append_file = str(prompt_append_file).strip() or None
+
+        return MCPAssistCustomToolManifest(
+            schema_version=CUSTOM_TOOL_SCHEMA_VERSION,
+            tool_id=tool_id,
+            name=name,
+            description=description,
+            version=version,
+            entrypoint=entrypoint,
+            capabilities=capabilities,
+            prompt_append_file=prompt_append_file,
+        )
+
+    def _instantiate_tool(
+        self,
+        tool_dir: Path,
+        manifest: MCPAssistCustomToolManifest,
+    ) -> MCPAssistExternalTool:
+        """Import and instantiate a tool class from a package entrypoint."""
+        module_name, class_name = manifest.entrypoint.split(":", 1)
+        module_name = module_name.strip()
+        class_name = class_name.strip()
+        if not module_name or not class_name:
+            raise ValueError("entrypoint must include both module and class name")
+
+        module_path = self._resolve_module_path(tool_dir, module_name)
+        try:
+            module_path.resolve().relative_to(tool_dir.resolve())
+        except ValueError as err:
+            raise ValueError("entrypoint module must stay within the tool directory") from err
+        unique_module_name = (
+            f"{self._module_namespace}.{manifest.tool_id}.{module_name.replace('.', '_')}"
+        )
+        spec = importlib.util.spec_from_file_location(unique_module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise ValueError(f"Unable to import module from {module_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[unique_module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(unique_module_name, None)
+            raise
+
+        tool_class = getattr(module, class_name, None)
+        if tool_class is None:
+            raise ValueError(f"Entrypoint class {class_name!r} not found")
+        if not isinstance(tool_class, type) or not issubclass(
+            tool_class, MCPAssistExternalTool
+        ):
+            raise ValueError(
+                f"{class_name!r} must subclass MCPAssistExternalTool"
+            )
+
+        return tool_class(self.hass, manifest, tool_dir)
+
+    def _resolve_module_path(self, tool_dir: Path, module_name: str) -> Path:
+        """Resolve an entrypoint module inside the tool package directory."""
+        relative_path = Path(*module_name.split("."))
+        file_path = (tool_dir / relative_path).with_suffix(".py")
+        if file_path.is_file():
+            return file_path
+
+        package_init = tool_dir / relative_path / "__init__.py"
+        if package_init.is_file():
+            return package_init
+
+        raise ValueError(f"Unable to resolve entrypoint module {module_name!r}")
+
+    def _normalize_tool_definitions(
+        self,
+        manifest: MCPAssistCustomToolManifest,
+        tool_definitions: Any,
+        *,
+        reserved_tool_names: set[str],
+    ) -> list[dict[str, Any]]:
+        """Validate, normalize, and de-duplicate tool definitions."""
+        if not isinstance(tool_definitions, list) or not tool_definitions:
+            raise ValueError("get_tool_definitions() must return a non-empty list")
+
+        normalized: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+        for tool_definition in tool_definitions:
+            if not isinstance(tool_definition, dict):
+                raise ValueError("Each tool definition must be an object")
+
+            tool_name = str(tool_definition.get("name") or "").strip()
+            if not _TOOL_NAME_PATTERN.match(tool_name):
+                raise ValueError(
+                    f"Tool name {tool_name!r} contains unsupported characters"
+                )
+            if self._require_tool_name_prefix and not tool_name.startswith(
+                f"{manifest.tool_id}_"
+            ):
+                raise ValueError(
+                    f"Tool name {tool_name!r} must be prefixed with '{manifest.tool_id}_'"
+                )
+            if tool_name in reserved_tool_names or tool_name in seen_names:
+                raise ValueError(
+                    f"Tool name {tool_name!r} conflicts with an existing tool"
+                )
+
+            description = str(tool_definition.get("description") or "").strip()
+            if not description:
+                raise ValueError(f"Tool {tool_name!r} is missing a description")
+            llm_description = self._compact_text(
+                str(
+                    tool_definition.get(
+                        "llmDescription", tool_definition.get("llm_description")
+                    )
+                    or ""
+                ),
+                max_len=180,
+            )
+
+            input_schema = tool_definition.get("inputSchema") or {}
+            if not isinstance(input_schema, dict):
+                raise ValueError(
+                    f"Tool {tool_name!r} inputSchema must be an object"
+                )
+            normalized_schema = dict(input_schema)
+            if not normalized_schema:
+                normalized_schema = {"type": "object", "properties": {}}
+            elif normalized_schema.get("type") == "object" and "properties" not in normalized_schema:
+                normalized_schema["properties"] = {}
+            routing_hints = self._normalize_routing_hints(
+                tool_name,
+                tool_definition,
+            )
+
+            normalized.append(
+                {
+                    **tool_definition,
+                    "name": tool_name,
+                    "description": description,
+                    **({"llmDescription": llm_description} if llm_description else {}),
+                    "inputSchema": normalized_schema,
+                    **({"routingHints": routing_hints} if routing_hints else {}),
+                }
+            )
+            seen_names.add(tool_name)
+
+        return normalized
+
+    def _normalize_routing_hints(
+        self,
+        tool_name: str,
+        tool_definition: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Normalize optional tool-selection hints without bloating prompts."""
+        routing = tool_definition.get("routing")
+        if not isinstance(routing, dict):
+            routing = {}
+
+        keywords = self._normalize_string_list(
+            routing.get("keywords", tool_definition.get("keywords")),
+            max_items=8,
+            max_len=40,
+        )
+        example_queries = self._normalize_string_list(
+            routing.get("example_queries", tool_definition.get("example_queries")),
+            max_items=4,
+            max_len=100,
+        )
+        preferred_when = self._compact_text(
+            str(
+                routing.get("preferred_when", tool_definition.get("preferred_when"))
+                or ""
+            ),
+            max_len=180,
+        )
+        returns = self._compact_text(
+            str(routing.get("returns", tool_definition.get("returns")) or ""),
+            max_len=160,
+        )
+
+        hints: dict[str, Any] = {}
+        if keywords:
+            hints["keywords"] = keywords
+        if example_queries:
+            hints["example_queries"] = example_queries
+        if preferred_when:
+            hints["preferred_when"] = preferred_when
+        if returns:
+            hints["returns"] = returns
+
+        raw_routing = tool_definition.get("routing")
+        if raw_routing is not None and not isinstance(raw_routing, dict):
+            raise ValueError(
+                f"Tool {tool_name!r} routing metadata must be an object when provided"
+            )
+
+        return hints
+
+    @staticmethod
+    def _normalize_string_list(
+        value: Any,
+        *,
+        max_items: int,
+        max_len: int,
+    ) -> list[str]:
+        """Normalize a short list of compact routing strings."""
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            value = [value]
+
+        normalized: list[str] = []
+        for item in value:
+            compact = ExternalCustomToolLoader._compact_text(
+                str(item or ""),
+                max_len=max_len,
+            )
+            if not compact or compact in normalized:
+                continue
+            normalized.append(compact)
+            if len(normalized) >= max_items:
+                break
+        return normalized
+
+    def _normalize_settings_schema(
+        self,
+        manifest: MCPAssistCustomToolManifest,
+        schema: Any,
+    ) -> dict[str, Any]:
+        """Normalize an optional settings schema declared by the tool."""
+        if schema in (None, {}):
+            return {}
+        if not isinstance(schema, dict):
+            raise ValueError(
+                f"Tool package {manifest.tool_id!r} get_settings_schema() must return an object"
+            )
+        normalized = dict(schema)
+        if not normalized:
+            return {}
+        if not normalized.get("type"):
+            normalized["type"] = "object"
+        if normalized.get("type") == "object" and "properties" not in normalized:
+            normalized["properties"] = {}
+        return normalized
+
+    async def _load_shared_settings(
+        self,
+        manifest: MCPAssistCustomToolManifest,
+        settings_schema: dict[str, Any],
+    ) -> tuple[dict[str, Any], str | None]:
+        """Load and validate shared package settings for a tool."""
+        settings_path = self.get_settings_root() / f"{manifest.tool_id}.json"
+        settings, file_exists = await self.hass.async_add_executor_job(
+            self._load_settings_file_with_status,
+            settings_path,
+            settings_schema,
+            True,
+            f"{manifest.tool_id} shared settings",
+        )
+        return settings, str(settings_path) if file_exists else None
+
+    async def load_profile_settings(
+        self,
+        loaded_tool: LoadedExternalTool,
+        profile_entry_id: str,
+    ) -> tuple[dict[str, Any], dict[str, Any], str | None]:
+        """Load an optional per-profile settings overlay for a tool."""
+        if not profile_entry_id:
+            return loaded_tool.shared_settings, {}, None
+
+        profile_path = (
+            self.get_settings_root()
+            / "profiles"
+            / profile_entry_id
+            / f"{loaded_tool.manifest.tool_id}.json"
+        )
+        profile_settings, file_exists = await self.hass.async_add_executor_job(
+            self._load_settings_file_with_status,
+            profile_path,
+            {},
+            True,
+            f"{loaded_tool.manifest.tool_id} profile settings for {profile_entry_id}",
+        )
+        merged_settings = self._deep_merge_dicts(
+            loaded_tool.shared_settings,
+            profile_settings,
+        )
+        if loaded_tool.settings_schema:
+            merged_settings = validate_and_normalize_json_value(
+                loaded_tool.settings_schema,
+                merged_settings,
+                path=f"{loaded_tool.manifest.tool_id} settings",
+            )
+        return (
+            merged_settings,
+            profile_settings,
+            str(profile_path) if file_exists else None,
+        )
+
+    def _load_settings_file_with_status(
+        self,
+        path: Path,
+        schema: dict[str, Any],
+        allow_missing: bool,
+        path_label: str,
+    ) -> tuple[dict[str, Any], bool]:
+        """Load a JSON settings file and validate it."""
+        file_exists = path.exists()
+        if not file_exists:
+            if allow_missing:
+                if schema:
+                    return (
+                        validate_and_normalize_json_value(schema, {}, path=path_label),
+                        False,
+                    )
+                return {}, False
+            raise ValueError(f"{path_label} file was not found: {path}")
+
+        try:
+            raw_data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as err:
+            raise ValueError(f"Invalid JSON in {path}: {err}") from err
+
+        if not isinstance(raw_data, dict):
+            raise ValueError(f"{path} must contain a JSON object")
+
+        try:
+            if schema:
+                return (
+                    validate_and_normalize_json_value(
+                        schema,
+                        raw_data,
+                        path=path_label,
+                    ),
+                    True,
+                )
+            return (
+                validate_and_normalize_json_value(
+                    {"type": "object", "properties": {}},
+                    raw_data,
+                    path=path_label,
+                ),
+                True,
+            )
+        except SchemaValidationError as err:
+            raise ValueError(str(err)) from err
+
+    def _deep_merge_dicts(
+        self,
+        base: dict[str, Any],
+        overlay: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Merge nested settings dictionaries with overlay precedence."""
+        merged = deepcopy(base)
+        for key, value in overlay.items():
+            if (
+                key in merged
+                and isinstance(merged[key], dict)
+                and isinstance(value, dict)
+            ):
+                merged[key] = self._deep_merge_dicts(merged[key], value)
+            else:
+                merged[key] = deepcopy(value)
+        return merged
+
+    async def _build_prompt_instructions(
+        self,
+        tool_dir: Path,
+        manifest: MCPAssistCustomToolManifest,
+        tool: MCPAssistExternalTool,
+        tool_names: tuple[str, ...] = (),
+    ) -> str:
+        """Build a compact prompt appendix for a tool package."""
+        prompt_file_text = await self._read_prompt_append_file(tool_dir, manifest)
+        runtime_instructions = str(tool.get_prompt_instructions() or "").strip()
+        instruction_parts = self._dedupe_instruction_parts(
+            [prompt_file_text, runtime_instructions]
+        )
+        if not instruction_parts:
+            fallback = self._build_prompt_fallback(manifest, tool_names)
+            if fallback:
+                instruction_parts = [fallback]
+
+        if not instruction_parts:
+            return ""
+
+        combined_body = "\n".join(instruction_parts).strip()
+        label = str(manifest.name or manifest.tool_id).strip()
+        if "\n" in combined_body:
+            indented_body = "\n".join(
+                f"  {line}" for line in combined_body.splitlines() if line.strip()
+            )
+            combined = f"- {label}:\n{indented_body}"
+        else:
+            combined = f"- {label}: {combined_body}"
+        return self._compact_prompt_block(
+            combined,
+            max_len=self._prompt_chars_per_tool,
+        )
+
+    async def _read_prompt_append_file(
+        self,
+        tool_dir: Path,
+        manifest: MCPAssistCustomToolManifest,
+    ) -> str:
+        """Read optional static prompt instructions from the package asynchronously."""
+        return await self.hass.async_add_executor_job(
+            self._read_prompt_append_file_from_disk,
+            tool_dir,
+            manifest,
+        )
+
+    def _read_prompt_append_file_from_disk(
+        self,
+        tool_dir: Path,
+        manifest: MCPAssistCustomToolManifest,
+    ) -> str:
+        """Read optional static prompt instructions from the package."""
+        if not manifest.prompt_append_file:
+            return ""
+
+        prompt_path = (tool_dir / manifest.prompt_append_file).resolve()
+        try:
+            prompt_path.relative_to(tool_dir.resolve())
+        except ValueError as err:
+            raise ValueError("prompt_append_file must stay within the tool directory") from err
+
+        if not prompt_path.is_file():
+            raise ValueError(
+                f"prompt_append_file {manifest.prompt_append_file!r} was not found"
+            )
+
+        return prompt_path.read_text(encoding="utf-8").strip()
+
+    @staticmethod
+    def _compact_text(text: str, *, max_len: int) -> str:
+        """Compact capability text for prompt use."""
+        normalized = " ".join(str(text).split()).strip()
+        for separator in (". ", "\n", "; "):
+            if separator in normalized:
+                normalized = normalized.split(separator, 1)[0].strip()
+                break
+        if len(normalized) <= max_len:
+            return normalized
+        trimmed = normalized[: max_len - 1].rstrip()
+        last_space = trimmed.rfind(" ")
+        if last_space > 40:
+            trimmed = trimmed[:last_space]
+        return trimmed.rstrip(" ,;:.") + "."
+
+    @staticmethod
+    def _compact_prompt_block(text: str, *, max_len: int) -> str:
+        """Compact prompt guidance while preserving short procedural components."""
+        lines = [
+            " ".join(line.strip().split())
+            for line in str(text or "").splitlines()
+            if line.strip()
+        ]
+        normalized = "\n".join(lines) if lines else " ".join(str(text).split()).strip()
+        if len(normalized) <= max_len:
+            return normalized
+
+        kept_lines: list[str] = []
+        current_len = 0
+        for line in lines:
+            candidate_len = current_len + (1 if kept_lines else 0) + len(line)
+            if candidate_len > max_len:
+                break
+            kept_lines.append(line)
+            current_len = candidate_len
+
+        if kept_lines:
+            return "\n".join(kept_lines)
+
+        trimmed = normalized[: max_len - 1].rstrip()
+        last_space = trimmed.rfind(" ")
+        if last_space > 40:
+            trimmed = trimmed[:last_space]
+        return trimmed.rstrip(" ,;:.") + "."
+
+    def _dedupe_instruction_parts(self, raw_parts: list[str]) -> list[str]:
+        """Normalize and deduplicate prompt-instruction fragments."""
+        normalized_parts: list[str] = []
+        seen: set[str] = set()
+        for part in raw_parts:
+            compact = self._compact_prompt_block(
+                part,
+                max_len=self._prompt_chars_per_tool,
+            )
+            if not compact:
+                continue
+            key = compact.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized_parts.append(compact)
+        return normalized_parts
+
+    def _build_prompt_fallback(
+        self,
+        manifest: MCPAssistCustomToolManifest,
+        tool_names: tuple[str, ...],
+    ) -> str:
+        """Build a minimal fallback prompt line when no prompt text is supplied."""
+        if tool_names:
+            preview = ", ".join(tool_names[:2])
+            if len(tool_names) > 2:
+                preview += ", ..."
+            return f"Use {preview} for {manifest.tool_id.replace('_', ' ')} questions."
+
+        if manifest.capabilities:
+            return self._compact_text(manifest.capabilities[0], max_len=140)
+
+        return ""
+
+
+def combine_prompt_instructions(
+    loaded_tools: list[LoadedExternalTool],
+    *,
+    heading: str = "## External Custom Tools",
+    truncated_notice: str = "[External custom tool instructions truncated.]",
+) -> str:
+    """Combine tool-package prompt appendices into one compact block."""
+    prompt_sections = [
+        tool.prompt_instructions.strip()
+        for tool in loaded_tools
+        if tool.prompt_instructions.strip()
+    ]
+    if not prompt_sections:
+        return ""
+
+    combined_lines = [heading.strip(), *prompt_sections]
+    combined = "\n".join(combined_lines)
+    if len(combined) <= _MAX_PROMPT_CHARS_TOTAL:
+        return combined
+
+    kept_lines = [heading.strip()]
+    current_len = len(heading.strip())
+    for section in prompt_sections:
+        candidate_len = current_len + 1 + len(section)
+        if candidate_len > _MAX_PROMPT_CHARS_TOTAL:
+            break
+        kept_lines.append(section)
+        current_len = candidate_len
+
+    if len(kept_lines) == 1:
+        truncated = heading.strip()[:_MAX_PROMPT_CHARS_TOTAL].rstrip()
+        return truncated + f"\n{truncated_notice}"
+
+    kept_lines.append(truncated_notice)
+    return "\n".join(kept_lines)

--- a/custom_components/mcp_assist/custom_tools/packages/calculator/mcp_tool.json
+++ b/custom_components/mcp_assist/custom_tools/packages/calculator/mcp_tool.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "id": "calculator",
+  "name": "Calculator",
+  "description": "Built-in arithmetic and expression-evaluation tools.",
+  "version": "1.1.0",
+  "entrypoint": "tool:CalculatorPackageTool",
+  "prompt_append_file": "prompt.md",
+  "capabilities": [
+    "Performs arithmetic and evaluates math expressions."
+  ],
+  "built_in_toggle": {
+    "tool_names": [
+      "add",
+      "subtract",
+      "multiply",
+      "divide",
+      "sqrt",
+      "power",
+      "round_number",
+      "average",
+      "min_value",
+      "max_value",
+      "evaluate_expression"
+    ],
+    "shared_setting_key": "enable_calculator_tools",
+    "profile_setting_key": "profile_enable_calculator_tools",
+    "shared_default": false,
+    "profile_default": true,
+    "shared_label": "Calculator",
+    "shared_description": "Expose exact arithmetic and expression-evaluation helpers.",
+    "profile_disable_label": "Disable Calculator",
+    "profile_disable_description": "Prevents this profile from using arithmetic and expression-evaluation tools."
+  }
+}

--- a/custom_components/mcp_assist/custom_tools/packages/calculator/prompt.md
+++ b/custom_components/mcp_assist/custom_tools/packages/calculator/prompt.md
@@ -1,0 +1,1 @@
+Use these tools for arithmetic or expression questions instead of doing math mentally. Call them for addition, subtraction, multiplication, division, roots, powers, rounding, averages, min/max, and expression evaluation.

--- a/custom_components/mcp_assist/custom_tools/packages/calculator/tool.py
+++ b/custom_components/mcp_assist/custom_tools/packages/calculator/tool.py
@@ -1,0 +1,39 @@
+"""Built-in calculator tool package wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+from custom_components.mcp_assist.custom_tools.calculator import CalculatorTool
+
+
+class CalculatorPackageTool(MCPAssistExternalTool):
+    """Expose the legacy calculator bundle through the package API."""
+
+    _EXCLUDED_TOOL_NAMES = {"convert_unit"}
+
+    def __init__(self, hass, manifest, tool_dir) -> None:
+        """Initialize the wrapper and delegated calculator bundle."""
+        super().__init__(hass, manifest, tool_dir)
+        self._delegate = CalculatorTool(hass)
+
+    async def initialize(self) -> None:
+        """Initialize the delegated calculator bundle."""
+        await self._delegate.initialize()
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return the delegated calculator tool definitions."""
+        return [
+            tool_definition
+            for tool_definition in self._delegate.get_tool_definitions()
+            if str(tool_definition.get("name") or "") not in self._EXCLUDED_TOOL_NAMES
+        ]
+
+    async def handle_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Delegate calculator tool calls to the legacy implementation."""
+        return await self._delegate.handle_call(tool_name, arguments)

--- a/custom_components/mcp_assist/custom_tools/packages/read_url/mcp_tool.json
+++ b/custom_components/mcp_assist/custom_tools/packages/read_url/mcp_tool.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "read_url",
+  "name": "Read URL",
+  "description": "Built-in URL content reader for web search follow-up flows.",
+  "version": "1.1.0",
+  "entrypoint": "tool:ReadUrlPackageTool",
+  "prompt_append_file": "prompt.md",
+  "capabilities": [
+    "Fetches and extracts page text from a URL so the assistant can inspect a specific search result."
+  ],
+  "built_in_toggle": {
+    "tool_names": [
+      "read_url"
+    ],
+    "shared_setting_key": "enable_read_url_tool",
+    "profile_setting_key": "profile_enable_read_url_tool",
+    "shared_default": true,
+    "profile_default": true,
+    "shared_label": "Read URL",
+    "profile_disable_label": "Disable Read URL",
+    "shared_description": "Expose URL reading so the assistant can inspect specific web pages.",
+    "profile_disable_description": "Prevents this profile from opening and extracting page content from URLs.",
+    "legacy_shared_setting_keys": [
+      "enable_web_search"
+    ],
+    "legacy_profile_setting_keys": [
+      "profile_enable_web_search"
+    ],
+    "requires_search_provider": true
+  }
+}

--- a/custom_components/mcp_assist/custom_tools/packages/read_url/prompt.md
+++ b/custom_components/mcp_assist/custom_tools/packages/read_url/prompt.md
@@ -1,0 +1,1 @@
+Use `read_url` after `search` when a specific page needs to be inspected or summarized from its URL.

--- a/custom_components/mcp_assist/custom_tools/packages/read_url/tool.py
+++ b/custom_components/mcp_assist/custom_tools/packages/read_url/tool.py
@@ -1,0 +1,33 @@
+"""Built-in read_url package wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+from custom_components.mcp_assist.custom_tools.read_url import ReadUrlTool
+
+
+class ReadUrlPackageTool(MCPAssistExternalTool):
+    """Expose the legacy read_url tool through the package API."""
+
+    def __init__(self, hass, manifest, tool_dir) -> None:
+        """Initialize the wrapper and delegated read_url tool."""
+        super().__init__(hass, manifest, tool_dir)
+        self._delegate = ReadUrlTool(hass)
+
+    async def initialize(self) -> None:
+        """Initialize the delegated read_url tool."""
+        await self._delegate.initialize()
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return the delegated read_url tool definition."""
+        return self._delegate.get_tool_definitions()
+
+    async def handle_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Delegate URL-reading tool calls to the legacy implementation."""
+        return await self._delegate.handle_call(tool_name, arguments)

--- a/custom_components/mcp_assist/custom_tools/packages/search/mcp_tool.json
+++ b/custom_components/mcp_assist/custom_tools/packages/search/mcp_tool.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "id": "search",
+  "name": "Search",
+  "description": "Built-in web search using the configured shared provider.",
+  "version": "1.1.0",
+  "entrypoint": "tool:SearchPackageTool",
+  "prompt_append_file": "prompt.md",
+  "capabilities": [
+    "Searches the web with the configured provider while preserving the standard MCP Assist search tool surface."
+  ],
+  "built_in_toggle": {
+    "tool_names": [
+      "search"
+    ],
+    "shared_setting_key": "enable_search_tool",
+    "profile_setting_key": "profile_enable_search_tool",
+    "shared_default": true,
+    "profile_default": true,
+    "shared_label": "Search",
+    "profile_disable_label": "Disable Search",
+    "shared_description": "Expose web search using the configured shared provider.",
+    "profile_disable_description": "Prevents this profile from using the built-in web search helper.",
+    "legacy_shared_setting_keys": [
+      "enable_web_search"
+    ],
+    "legacy_profile_setting_keys": [
+      "profile_enable_web_search"
+    ],
+    "requires_search_provider": true
+  }
+}

--- a/custom_components/mcp_assist/custom_tools/packages/search/prompt.md
+++ b/custom_components/mcp_assist/custom_tools/packages/search/prompt.md
@@ -1,0 +1,1 @@
+Use `search` for current-events, latest, today, or right-now news questions that need internet lookup through the configured provider; if snippets are too thin, follow with `read_url` on a promising result.

--- a/custom_components/mcp_assist/custom_tools/packages/search/tool.py
+++ b/custom_components/mcp_assist/custom_tools/packages/search/tool.py
@@ -1,0 +1,88 @@
+"""Built-in search tool package wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.mcp_assist import get_system_entry
+from custom_components.mcp_assist.const import (
+    CONF_BRAVE_API_KEY,
+    CONF_ENABLE_CUSTOM_TOOLS,
+    CONF_SEARCH_PROVIDER,
+    DEFAULT_BRAVE_API_KEY,
+)
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+
+
+class SearchPackageTool(MCPAssistExternalTool):
+    """Expose the configured search provider through the package API."""
+
+    def __init__(self, hass, manifest, tool_dir) -> None:
+        """Initialize the search wrapper."""
+        super().__init__(hass, manifest, tool_dir)
+        self._delegate: Any | None = None
+
+    async def initialize(self) -> None:
+        """Initialize the configured search provider."""
+        provider = self._get_search_provider()
+        if provider == "brave":
+            from custom_components.mcp_assist.custom_tools.brave_search import (
+                BraveSearchTool,
+            )
+
+            self._delegate = BraveSearchTool(
+                self.hass,
+                self._get_shared_setting(CONF_BRAVE_API_KEY, DEFAULT_BRAVE_API_KEY),
+            )
+        elif provider == "duckduckgo":
+            from custom_components.mcp_assist.custom_tools.duckduckgo_search import (
+                DuckDuckGoSearchTool,
+            )
+
+            self._delegate = DuckDuckGoSearchTool(self.hass)
+        else:
+            raise ValueError(
+                "Built-in search package loaded without a supported search provider."
+            )
+
+        await self._delegate.initialize()
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return the delegated search tool definition."""
+        return self._require_delegate().get_tool_definitions()
+
+    async def handle_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Delegate search tool calls to the configured provider."""
+        return await self._require_delegate().handle_call(tool_name, arguments)
+
+    def _get_shared_setting(self, key: str, default: Any = None) -> Any:
+        """Read a shared MCP Assist setting from the system entry."""
+        system_entry = get_system_entry(self.hass)
+        if system_entry is None:
+            return default
+
+        value = system_entry.options.get(key, system_entry.data.get(key))
+        if value is not None:
+            return value
+        return default
+
+    def _get_search_provider(self) -> str:
+        """Return the effective shared search provider."""
+        provider = self._get_shared_setting(CONF_SEARCH_PROVIDER)
+        if provider:
+            return str(provider)
+
+        if self._get_shared_setting(CONF_ENABLE_CUSTOM_TOOLS, False):
+            return "brave"
+
+        return "none"
+
+    def _require_delegate(self) -> Any:
+        """Return the configured provider implementation."""
+        if self._delegate is None:
+            raise RuntimeError("Search package was not initialized")
+        return self._delegate

--- a/custom_components/mcp_assist/custom_tools/packages/unit_conversion/mcp_tool.json
+++ b/custom_components/mcp_assist/custom_tools/packages/unit_conversion/mcp_tool.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "id": "unit_conversion",
+  "name": "Unit Conversion",
+  "description": "Built-in exact unit-conversion tools.",
+  "version": "1.0.0",
+  "entrypoint": "tool:UnitConversionPackageTool",
+  "prompt_append_file": "prompt.md",
+  "capabilities": [
+    "Converts between common temperature, length, weight, energy, storage, and data-rate units."
+  ],
+  "built_in_toggle": {
+    "tool_names": [
+      "convert_unit"
+    ],
+    "shared_setting_key": "enable_unit_conversion_tools",
+    "profile_setting_key": "profile_enable_unit_conversion_tools",
+    "shared_default": false,
+    "profile_default": true,
+    "shared_label": "Unit Conversion",
+    "profile_disable_label": "Disable Unit Conversion",
+    "shared_description": "Expose exact unit-conversion helpers.",
+    "profile_disable_description": "Prevents this profile from using exact unit-conversion helpers.",
+    "legacy_shared_setting_keys": [
+      "enable_calculator_tools"
+    ],
+    "legacy_profile_setting_keys": [
+      "profile_enable_calculator_tools"
+    ]
+  }
+}

--- a/custom_components/mcp_assist/custom_tools/packages/unit_conversion/prompt.md
+++ b/custom_components/mcp_assist/custom_tools/packages/unit_conversion/prompt.md
@@ -1,0 +1,1 @@
+Use `convert_unit` for exact conversions between units like temperature, distance, weight, storage, energy, or data rate.

--- a/custom_components/mcp_assist/custom_tools/packages/unit_conversion/tool.py
+++ b/custom_components/mcp_assist/custom_tools/packages/unit_conversion/tool.py
@@ -1,0 +1,37 @@
+"""Built-in unit-conversion package wrapper."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+from custom_components.mcp_assist.custom_tools.calculator import CalculatorTool
+
+
+class UnitConversionPackageTool(MCPAssistExternalTool):
+    """Expose only the legacy convert_unit tool through the package API."""
+
+    def __init__(self, hass, manifest, tool_dir) -> None:
+        """Initialize the wrapper and delegated calculator bundle."""
+        super().__init__(hass, manifest, tool_dir)
+        self._delegate = CalculatorTool(hass)
+
+    async def initialize(self) -> None:
+        """Initialize the delegated calculator bundle."""
+        await self._delegate.initialize()
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Return only the unit-conversion tool definition."""
+        return [
+            tool_definition
+            for tool_definition in self._delegate.get_tool_definitions()
+            if str(tool_definition.get("name") or "") == "convert_unit"
+        ]
+
+    async def handle_call(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Delegate unit-conversion calls to the legacy implementation."""
+        return await self._delegate.handle_call(tool_name, arguments)

--- a/custom_components/mcp_assist/custom_tools/schema_utils.py
+++ b/custom_components/mcp_assist/custom_tools/schema_utils.py
@@ -1,0 +1,270 @@
+"""Lightweight JSON-schema-style validation helpers for external tools."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class SchemaValidationError(ValueError):
+    """Raised when data does not match a supported schema shape."""
+
+
+def validate_and_normalize_json_value(
+    schema: dict[str, Any] | None,
+    value: Any,
+    *,
+    path: str = "value",
+) -> Any:
+    """Validate a limited JSON-schema-style payload and apply defaults."""
+    if not isinstance(schema, dict) or not schema:
+        return value
+
+    if value is None and "default" in schema:
+        value = deepcopy(schema["default"])
+
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list) and one_of:
+        errors: list[str] = []
+        for option in one_of:
+            try:
+                return validate_and_normalize_json_value(option, value, path=path)
+            except SchemaValidationError as err:
+                errors.append(str(err))
+        raise SchemaValidationError(
+            f"{path} did not match any allowed schema option"
+        )
+
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list) and any_of:
+        errors: list[str] = []
+        for option in any_of:
+            try:
+                return validate_and_normalize_json_value(option, value, path=path)
+            except SchemaValidationError as err:
+                errors.append(str(err))
+        raise SchemaValidationError(
+            f"{path} did not match any allowed schema option"
+        )
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        last_error: SchemaValidationError | None = None
+        for option in schema_type:
+            try:
+                return validate_and_normalize_json_value(
+                    {**schema, "type": option},
+                    value,
+                    path=path,
+                )
+            except SchemaValidationError as err:
+                last_error = err
+        raise last_error or SchemaValidationError(
+            f"{path} did not match any allowed type"
+        )
+
+    if schema_type == "object" or (
+        schema_type is None and isinstance(schema.get("properties"), dict)
+    ):
+        return _validate_object(schema, value, path=path)
+    if schema_type == "array":
+        return _validate_array(schema, value, path=path)
+    if schema_type == "string":
+        return _validate_string(schema, value, path=path)
+    if schema_type == "integer":
+        return _validate_integer(schema, value, path=path)
+    if schema_type == "number":
+        return _validate_number(schema, value, path=path)
+    if schema_type == "boolean":
+        return _validate_boolean(schema, value, path=path)
+
+    normalized = value
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_object(schema: dict[str, Any], value: Any, *, path: str) -> dict[str, Any]:
+    if value is None:
+        value = {}
+    if not isinstance(value, dict):
+        raise SchemaValidationError(f"{path} must be an object")
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        properties = {}
+    required = schema.get("required")
+    if not isinstance(required, list):
+        required = []
+    additional_properties = schema.get("additionalProperties", True)
+
+    normalized: dict[str, Any] = {}
+    missing: list[str] = []
+    for prop_name, prop_schema in properties.items():
+        prop_path = f"{path}.{prop_name}"
+        if prop_name in value:
+            normalized[prop_name] = validate_and_normalize_json_value(
+                prop_schema,
+                value[prop_name],
+                path=prop_path,
+            )
+        elif isinstance(prop_schema, dict) and "default" in prop_schema:
+            normalized[prop_name] = validate_and_normalize_json_value(
+                prop_schema,
+                deepcopy(prop_schema.get("default")),
+                path=prop_path,
+            )
+        elif prop_name in required:
+            missing.append(prop_name)
+
+    if missing:
+        raise SchemaValidationError(
+            f"{path} is missing required field(s): {', '.join(sorted(missing))}"
+        )
+
+    for extra_key, extra_value in value.items():
+        if extra_key in properties:
+            continue
+        extra_path = f"{path}.{extra_key}"
+        if additional_properties is False:
+            raise SchemaValidationError(f"{extra_path} is not allowed")
+        if isinstance(additional_properties, dict):
+            normalized[extra_key] = validate_and_normalize_json_value(
+                additional_properties,
+                extra_value,
+                path=extra_path,
+            )
+        else:
+            normalized[extra_key] = extra_value
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_array(schema: dict[str, Any], value: Any, *, path: str) -> list[Any]:
+    if value is None and "default" in schema:
+        value = deepcopy(schema["default"])
+    if not isinstance(value, list):
+        if isinstance(value, tuple):
+            value = list(value)
+        else:
+            raise SchemaValidationError(f"{path} must be an array")
+
+    items_schema = schema.get("items")
+    normalized = [
+        validate_and_normalize_json_value(
+            items_schema if isinstance(items_schema, dict) else {},
+            item,
+            path=f"{path}[{index}]",
+        )
+        for index, item in enumerate(value)
+    ]
+
+    min_items = schema.get("minItems")
+    if isinstance(min_items, int) and len(normalized) < min_items:
+        raise SchemaValidationError(f"{path} must contain at least {min_items} item(s)")
+    max_items = schema.get("maxItems")
+    if isinstance(max_items, int) and len(normalized) > max_items:
+        raise SchemaValidationError(f"{path} must contain at most {max_items} item(s)")
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_string(schema: dict[str, Any], value: Any, *, path: str) -> str:
+    if value is None:
+        raise SchemaValidationError(f"{path} must be a string")
+    if isinstance(value, (dict, list, tuple, set)):
+        raise SchemaValidationError(f"{path} must be a string")
+
+    normalized = str(value)
+    min_length = schema.get("minLength")
+    if isinstance(min_length, int) and len(normalized) < min_length:
+        raise SchemaValidationError(f"{path} must be at least {min_length} character(s)")
+    max_length = schema.get("maxLength")
+    if isinstance(max_length, int) and len(normalized) > max_length:
+        raise SchemaValidationError(f"{path} must be at most {max_length} character(s)")
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_integer(schema: dict[str, Any], value: Any, *, path: str) -> int:
+    if isinstance(value, bool):
+        raise SchemaValidationError(f"{path} must be an integer")
+    if isinstance(value, int):
+        normalized = value
+    elif isinstance(value, float) and value.is_integer():
+        normalized = int(value)
+    elif isinstance(value, str):
+        text_value = value.strip()
+        try:
+            normalized = int(text_value)
+        except ValueError as err:
+            raise SchemaValidationError(f"{path} must be an integer") from err
+    else:
+        raise SchemaValidationError(f"{path} must be an integer")
+
+    minimum = schema.get("minimum")
+    if isinstance(minimum, (int, float)) and normalized < minimum:
+        raise SchemaValidationError(f"{path} must be >= {minimum}")
+    maximum = schema.get("maximum")
+    if isinstance(maximum, (int, float)) and normalized > maximum:
+        raise SchemaValidationError(f"{path} must be <= {maximum}")
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_number(schema: dict[str, Any], value: Any, *, path: str) -> float | int:
+    if isinstance(value, bool):
+        raise SchemaValidationError(f"{path} must be a number")
+    if isinstance(value, (int, float)):
+        normalized: float | int = value
+    elif isinstance(value, str):
+        text_value = value.strip()
+        try:
+            normalized = float(text_value)
+        except ValueError as err:
+            raise SchemaValidationError(f"{path} must be a number") from err
+    else:
+        raise SchemaValidationError(f"{path} must be a number")
+
+    minimum = schema.get("minimum")
+    if isinstance(minimum, (int, float)) and normalized < minimum:
+        raise SchemaValidationError(f"{path} must be >= {minimum}")
+    maximum = schema.get("maximum")
+    if isinstance(maximum, (int, float)) and normalized > maximum:
+        raise SchemaValidationError(f"{path} must be <= {maximum}")
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_boolean(schema: dict[str, Any], value: Any, *, path: str) -> bool:
+    if isinstance(value, bool):
+        normalized = value
+    elif isinstance(value, (int, float)) and value in {0, 1}:
+        normalized = bool(value)
+    elif isinstance(value, str):
+        text_value = value.strip().lower()
+        if text_value in {"true", "1", "yes", "on"}:
+            normalized = True
+        elif text_value in {"false", "0", "no", "off"}:
+            normalized = False
+        else:
+            raise SchemaValidationError(f"{path} must be a boolean")
+    else:
+        raise SchemaValidationError(f"{path} must be a boolean")
+
+    _validate_enum_and_const(schema, normalized, path=path)
+    return normalized
+
+
+def _validate_enum_and_const(schema: dict[str, Any], value: Any, *, path: str) -> None:
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and value not in enum_values:
+        raise SchemaValidationError(
+            f"{path} must be one of: {', '.join(str(item) for item in enum_values)}"
+        )
+    if "const" in schema and value != schema["const"]:
+        raise SchemaValidationError(f"{path} must equal {schema['const']!r}")

--- a/custom_components/mcp_assist/mcp_server.py
+++ b/custom_components/mcp_assist/mcp_server.py
@@ -25,8 +25,10 @@ from .const import (
     CONF_ALLOWED_IPS,
     CONF_SEARCH_PROVIDER,
     CONF_ENABLE_CUSTOM_TOOLS,
+    CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
     DEFAULT_LMSTUDIO_URL,
     DEFAULT_ALLOWED_IPS,
+    DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
 )
 from .discovery import EntityDiscovery
 from .domain_registry import (
@@ -138,6 +140,15 @@ class MCPServer:
 
         return "none"
 
+    def _external_custom_tools_enabled(self) -> bool:
+        """Return whether user-defined external custom tool packages are enabled."""
+        return bool(
+            self._get_shared_setting(
+                CONF_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+                DEFAULT_ENABLE_EXTERNAL_CUSTOM_TOOLS,
+            )
+        )
+
     async def start(self) -> None:
         """Start the MCP server."""
         try:
@@ -154,6 +165,10 @@ class MCPServer:
             self.app.router.add_get("/ws", self.handle_websocket)
             self.app.router.add_get("/health", self.handle_health)
             self.app.router.add_get(
+                "/external-tools/diagnostics",
+                self.handle_external_tool_diagnostics,
+            )
+            self.app.router.add_get(
                 "/progress", self.handle_progress_stream
             )  # Progress streaming
 
@@ -164,21 +179,20 @@ class MCPServer:
             self.site = web.TCPSite(self.runner, "0.0.0.0", self.port)
             await self.site.start()
 
-            # Create and initialize custom tools if search provider is enabled
+            # Create and initialize built-in package wrappers and optional external tools
             # Done here (not in __init__) so system entry exists for reading settings
-            search_provider = self._get_search_provider()
-            if search_provider in ["brave", "duckduckgo"]:
-                try:
-                    from .custom_tools import CustomToolsLoader
+            try:
+                from .custom_tools import CustomToolsLoader
 
-                    self.custom_tools = CustomToolsLoader(self.hass, self.entry)
-                    await self.custom_tools.initialize()
-                    _LOGGER.info(
-                        "✅ Custom tools initialized for search provider: %s",
-                        search_provider,
-                    )
-                except Exception as e:
-                    _LOGGER.error(f"Failed to initialize custom tools: {e}")
+                self.custom_tools = CustomToolsLoader(self.hass, self.entry)
+                await self.custom_tools.initialize()
+                _LOGGER.info(
+                    "✅ Custom tools initialized (search provider: %s, external enabled: %s)",
+                    self._get_search_provider(),
+                    self._external_custom_tools_enabled(),
+                )
+            except Exception as e:
+                _LOGGER.error(f"Failed to initialize custom tools: {e}")
 
             _LOGGER.info(
                 "✅ MCP server started successfully on http://0.0.0.0:%d", self.port
@@ -215,6 +229,10 @@ class MCPServer:
     async def stop(self) -> None:
         """Stop the MCP server."""
         _LOGGER.info("Stopping MCP server")
+
+        if self.custom_tools:
+            await self.custom_tools.shutdown()
+            self.custom_tools = None
 
         if self.site:
             await self.site.stop()
@@ -296,9 +314,77 @@ class MCPServer:
                 "health": f"http://<host>:{self.port}/health",
             },
             "tools_available": len(await self._get_tools_list()),
+            "external_custom_tools_enabled": self._external_custom_tools_enabled(),
             "timestamp": dt_util.now().isoformat(),
         }
+        if self.custom_tools:
+            get_loaded_builtin_tool_info = getattr(
+                self.custom_tools,
+                "get_loaded_builtin_tool_info",
+                None,
+            )
+            if callable(get_loaded_builtin_tool_info):
+                health_info["built_in_tool_packages"] = get_loaded_builtin_tool_info()
+            health_info["external_custom_tools_loaded"] = (
+                self.custom_tools.get_loaded_external_tool_info()
+            )
         return web.json_response(health_info)
+
+    async def handle_external_tool_diagnostics(
+        self,
+        request: web.Request,
+    ) -> web.Response:
+        """Return diagnostics for manifest-based custom tool packages."""
+        client_ip = request.remote
+        _LOGGER.info("🧰 External tool diagnostics request from %s", client_ip)
+
+        if not self._is_ip_allowed(client_ip):
+            _LOGGER.warning(
+                "🚫 Blocked external tool diagnostics request from unauthorized IP: %s",
+                client_ip,
+            )
+            return web.Response(status=403, text="Forbidden: IP not authorized")
+
+        diagnostics: dict[str, Any] = {
+            "external_custom_tools_enabled": self._external_custom_tools_enabled(),
+            "external_packages": [],
+            "external_load_errors": [],
+        }
+        if self.custom_tools:
+            get_package_diagnostics = getattr(
+                self.custom_tools,
+                "get_package_diagnostics",
+                None,
+            )
+            if callable(get_package_diagnostics):
+                diagnostics = get_package_diagnostics()
+
+        return web.json_response(diagnostics)
+
+    async def reload_external_custom_tools(self) -> dict[str, Any]:
+        """Reload manifest-based custom tool packages and notify MCP clients."""
+        if not self.custom_tools:
+            return {
+                "external_custom_tools_enabled": self._external_custom_tools_enabled(),
+                "external_packages": [],
+                "external_load_errors": ["Custom tool loader is not initialized"],
+            }
+
+        reload_tool_packages = getattr(self.custom_tools, "reload_tool_packages", None)
+        if callable(reload_tool_packages):
+            diagnostics = await reload_tool_packages()
+        else:
+            reload_external_tools = getattr(self.custom_tools, "reload_external_tools", None)
+            if not callable(reload_external_tools):
+                return {
+                    "external_custom_tools_enabled": self._external_custom_tools_enabled(),
+                    "external_packages": [],
+                    "external_load_errors": ["Custom tool reload is not available"],
+                }
+            diagnostics = await reload_external_tools()
+
+        await self.broadcast_notification("notifications/tools/list_changed")
+        return diagnostics
 
     async def handle_progress_stream(self, request: web.Request) -> web.StreamResponse:
         """SSE endpoint for progress updates during tool execution."""
@@ -963,6 +1049,7 @@ class MCPServer:
         """Handle tools/call request."""
         tool_name = params.get("name")
         arguments = params.get("arguments", {})
+        context = params.get("context")
 
         _LOGGER.debug("Calling tool: %s with args: %s", tool_name, arguments)
 
@@ -989,7 +1076,11 @@ class MCPServer:
         else:
             # Check if it's a custom tool
             if self.custom_tools and self.custom_tools.is_custom_tool(tool_name):
-                return await self.custom_tools.handle_tool_call(tool_name, arguments)
+                return await self.custom_tools.handle_tool_call(
+                    tool_name,
+                    arguments,
+                    context=context if isinstance(context, dict) else None,
+                )
             else:
                 raise ValueError(f"Unknown tool: {tool_name}")
 

--- a/custom_components/mcp_assist/services.yaml
+++ b/custom_components/mcp_assist/services.yaml
@@ -1,0 +1,3 @@
+reload_external_custom_tools:
+  name: Reload external custom tools
+  description: Reload manifest-based MCP Assist custom tool packages.

--- a/custom_components/mcp_assist/strings.json
+++ b/custom_components/mcp_assist/strings.json
@@ -63,7 +63,10 @@
           "search_provider": "Web Search",
           "brave_api_key": "Brave Search API Key",
           "allowed_ips": "Additional Allowed IPs/Ranges",
-          "enable_gap_filling": "Enable Smart Entity Index"
+          "enable_gap_filling": "Enable Smart Entity Index",
+          "enable_external_custom_tools": "Enable External Custom Tools",
+          "enable_calculator_tools": "Enable Calculator Tools",
+          "enable_unit_conversion_tools": "Enable Unit Conversion Tools"
         }
       }
     },
@@ -126,6 +129,9 @@
           "brave_api_key": "Brave Search API Key",
           "allowed_ips": "Additional Allowed IPs/Ranges",
           "enable_gap_filling": "Enable Smart Entity Index",
+          "enable_external_custom_tools": "Enable External Custom Tools",
+          "enable_calculator_tools": "Enable Calculator Tools",
+          "enable_unit_conversion_tools": "Enable Unit Conversion Tools",
           "max_entities_per_discovery": "Max Entities Per Discovery (20-500)"
         }
       }

--- a/custom_components/mcp_assist/translations/en.json
+++ b/custom_components/mcp_assist/translations/en.json
@@ -64,6 +64,9 @@
           "brave_api_key": "Brave Search API Key",
           "allowed_ips": "Additional Allowed IPs/Ranges",
           "enable_gap_filling": "Enable Smart Entity Index",
+          "enable_external_custom_tools": "Enable External Custom Tools",
+          "enable_calculator_tools": "Enable Calculator Tools",
+          "enable_unit_conversion_tools": "Enable Unit Conversion Tools",
           "max_entities_per_discovery": "Max Entities Per Discovery (20-500)"
         }
       }
@@ -127,6 +130,9 @@
           "brave_api_key": "Brave Search API Key",
           "allowed_ips": "Additional Allowed IPs/Ranges",
           "enable_gap_filling": "Enable Smart Entity Index",
+          "enable_external_custom_tools": "Enable External Custom Tools",
+          "enable_calculator_tools": "Enable Calculator Tools",
+          "enable_unit_conversion_tools": "Enable Unit Conversion Tools",
           "max_entities_per_discovery": "Max Entities Per Discovery (20-500)"
         }
       }

--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -1,0 +1,394 @@
+# External Custom Tools for MCP Assist
+
+MCP Assist can load additional MCP tool packages from your Home Assistant config directory.
+
+This is intended for advanced users who want to:
+
+- expose integration-specific read helpers
+- add custom component behavior
+- bundle installation-specific helper logic
+- extend MCP Assist without forking the integration
+
+It also keeps user extensions out of the HACS-managed integration directory, which is the recommended upgrade-safe pattern for Home Assistant customizations.
+
+## What Belongs Where
+
+For most users, the right place to add new behavior is an external custom tool package under `<home-assistant-config>/mcp-assist-tools`.
+
+External custom tools are the recommended place for capabilities that are installation-specific, such as:
+
+- local custom components, recorder/audit tables, or local scripts
+- relationship aliases, vehicle nicknames, room aliases, or local naming conventions
+- city-specific schedules, site-specific camera zones, or custom dashboards
+
+If a capability only works because it knows details about one installation or one set of custom entities, it should stay in `<home-assistant-config>/mcp-assist-tools` instead of requiring changes to MCP Assist itself.
+
+If you are contributing directly to the MCP Assist project, core changes should usually be reserved for capabilities that are broadly reusable across many Home Assistant installations, such as:
+
+- generic web, math, or entity/service helpers
+- tools that operate on standard Home Assistant entities or services without assuming one specific layout
+- features that should be trusted and available as part of MCP Assist itself
+
+## Safety Model
+
+External custom tools are intentionally **safe by default**:
+
+- Disabled by default in the shared MCP server settings
+- Loaded only from `<home-assistant-config>/mcp-assist-tools`
+- Skipped when invalid instead of crashing the MCP server
+- Cannot override built-in MCP Assist tool names
+- Must use namespaced tool names
+- Cannot load from symlinked package directories
+- Cannot reference entrypoint modules or prompt files outside the package directory
+
+Important: once enabled, these packages run as Python code inside Home Assistant. Only install or write packages you trust.
+
+## How to Enable
+
+1. Create one or more tool packages under `<home-assistant-config>/mcp-assist-tools`
+2. In MCP Assist shared MCP server settings, enable **Custom Tools**
+3. Reload the integration or restart Home Assistant
+
+When enabled, MCP Assist will:
+
+- discover valid packages at startup
+- expose their MCP tools alongside built-in tools
+- append short tool-specific prompt guidance when provided
+- validate external-tool arguments against `inputSchema` before dispatch
+- merge optional shared/profile settings when a package declares a settings schema
+
+## Directory Layout
+
+Each tool package lives in its own folder:
+
+```text
+<home-assistant-config>/
+  mcp-assist-tools/
+    __shared__/
+      helpers.py
+    my_tool/
+      mcp_tool.json
+      tool.py
+      prompt.md
+```
+
+Rules:
+
+- The package folder name must match the manifest `id`
+- Hidden folders and `__*` folders are ignored
+- Symlinked package folders are rejected
+- `__shared__/` is reserved for helper modules that multiple packages can import
+
+## Manifest Format
+
+Each package must contain an `mcp_tool.json`.
+
+This namespaced filename avoids collisions with Home Assistant validation tools and generic manifest conventions.
+
+Current schema:
+
+```json
+{
+  "schema_version": 1,
+  "id": "my_tool",
+  "name": "My Tool",
+  "description": "Short description of what this package adds.",
+  "version": "1.0.0",
+  "entrypoint": "tool:MyTool",
+  "capabilities": [
+    "Optional short capability summary shown to the model"
+  ],
+  "prompt_append_file": "prompt.md"
+}
+```
+
+### Manifest Fields
+
+- `schema_version`
+  - Required
+  - Must currently be `1`
+- `id`
+  - Required
+  - Lowercase letters, numbers, and underscores only
+  - Must match the package folder name
+- `name`
+  - Required
+  - Human-readable package name
+- `description`
+  - Required
+  - Human-readable package description
+- `version`
+  - Required
+  - Free-form version string
+- `entrypoint`
+  - Required
+  - Must be in `module:ClassName` format
+- `capabilities`
+  - Optional
+  - List of short strings describing what the package can do
+- `prompt_append_file`
+  - Optional
+  - Relative file path inside the package
+  - Used to append compact technical guidance for the model
+
+## Python API
+
+Custom tools should import the stable MCP Assist tool API:
+
+```python
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+```
+
+The entrypoint class must subclass `MCPAssistExternalTool`.
+
+### Required methods
+
+- `get_tool_definitions(self) -> list[dict[str, Any]]`
+- `handle_call(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]`
+
+### Optional hooks
+
+- `initialize(self) -> None`
+- `async_shutdown(self) -> None`
+- `get_prompt_instructions(self) -> str`
+- `get_settings_schema(self) -> dict[str, Any]`
+
+### Shared helpers
+
+If you want several narrow packages to share code, use the first-class helper loader:
+
+```python
+from custom_components.mcp_assist.custom_tool_api import (
+    MCPAssistExternalTool,
+    load_external_shared_module,
+)
+
+shared = load_external_shared_module(__file__, "helpers")
+```
+
+MCP Assist loads these helpers from:
+
+- `<home-assistant-config>/mcp-assist-tools/__shared__/`
+
+This avoids ad-hoc `sys.path` shims and keeps package imports collision-safe.
+
+### Package settings
+
+External packages can declare an optional settings schema:
+
+```python
+def get_settings_schema(self) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            "default_camera": {"type": "string"},
+            "zones": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+        },
+    }
+```
+
+When present, MCP Assist will load and validate settings from:
+
+- Shared: `<home-assistant-config>/mcp-assist-tool-settings/<tool_id>.json`
+- Per-profile override: `<home-assistant-config>/mcp-assist-tool-settings/profiles/<profile_entry_id>/<tool_id>.json`
+
+During a tool call, packages can read:
+
+- `self.get_settings()`
+- `self.get_shared_settings()`
+- `self.get_profile_settings()`
+- `self.get_call_context()`
+
+### Reusing core MCP tools
+
+External packages can call built-in MCP Assist tools instead of reimplementing
+shared behavior:
+
+```python
+result = await self.call_mcp_tool(
+    "get_entity_details",
+    {"entity_id": "sensor.outdoor_temperature"},
+)
+```
+
+Shared helper modules can do the same with the module-level helpers:
+
+```python
+from custom_components.mcp_assist.custom_tool_api import (
+    call_mcp_tool,
+    get_external_tool_call_context,
+)
+
+result = await call_mcp_tool(
+    hass,
+    "discover_entities",
+    {"domain": "light", "limit": 20},
+    context=get_external_tool_call_context(),
+)
+```
+
+This keeps package prompts smaller, preserves active-profile model selection,
+and lets external suites compose generic MCP Assist capabilities without
+duplicating built-in tool logic.
+
+## Tool Definition Rules
+
+Each tool definition must:
+
+- be an MCP tool definition object
+- include `name`
+- include `description`
+- include `inputSchema`
+
+Tool names must:
+
+- contain only letters, numbers, `_`, or `-`
+- be namespaced with the manifest id
+- start with `<id>_`
+
+Example:
+
+- valid: `my_tool_status`
+- invalid: `status`
+- invalid: `discover_entities`
+
+MCP Assist rejects tool-name collisions with built-in tools or other external packages.
+
+## Routing Metadata
+
+To keep the initial prompt small, external tools can add lightweight routing hints directly on the tool definition instead of inflating prompt appendices:
+
+```python
+{
+    "name": "my_tool_status",
+    "description": "Return package status.",
+    "inputSchema": {"type": "object", "properties": {}},
+    "keywords": ["status", "health", "custom"],
+    "example_queries": ["What's the custom system status?"],
+    "preferred_when": "Use when the user asks about this package's state.",
+    "returns": "A short status summary.",
+}
+```
+
+You can also place the same fields under a nested `routing` object. MCP Assist normalizes these hints into `routingHints` and uses them when converting MCP tools into compact LLM tool descriptions.
+
+## Prompt Guidance
+
+External tools can teach the model how to use them in two ways:
+
+1. Static text file via `prompt_append_file`
+2. Dynamic text from `get_prompt_instructions()`
+
+These appendices should be:
+
+- short
+- procedural
+- tool-usage focused
+
+They should not:
+
+- restate the entire system prompt
+- include long examples unless absolutely necessary
+- dump large environment-specific data
+
+Prefer routing metadata over longer prompt text when a hint can be expressed structurally.
+
+MCP Assist automatically truncates overly long external prompt additions to keep context usage small.
+
+## Return Format
+
+`handle_call()` should return standard MCP tool results, for example:
+
+```python
+return {
+    "content": [
+        {"type": "text", "text": "Kitchen scene is active."}
+    ],
+    "isError": False,
+}
+```
+
+For errors, prefer returning a normal tool error result instead of raising when the failure is expected:
+
+```python
+return {
+    "content": [
+        {"type": "text", "text": "Scene is not available right now."}
+    ],
+    "isError": True,
+}
+```
+
+External tools may also return structured MCP results such as:
+
+- multiple content blocks
+- `structuredContent`
+
+MCP Assist preserves these results in the MCP server response.
+
+## Best Practices
+
+Follow these guidelines to keep packages portable and maintainable:
+
+- Prefer small, narrow tools over one huge catch-all tool
+- Use Home Assistant APIs and current state instead of hardcoded assumptions
+- Keep tool names stable
+- Keep prompt additions concise
+- Prefer routing metadata for discoverability before adding more prompt text
+- Use async-safe Home Assistant patterns
+- Avoid blocking I/O in tool calls
+- Avoid installing or expecting third-party Python dependencies
+- Do not assume a specific entity ID, area name, floor name, or user
+- Return structured, factual results and let the model phrase them naturally
+
+## Reloading and Diagnostics
+
+You no longer need a full restart just to iterate on package code:
+
+- Home Assistant service: `mcp_assist.reload_external_custom_tools`
+- Diagnostics endpoint: `GET /external-tools/diagnostics`
+
+The diagnostics endpoint reports:
+
+- whether external tools are enabled
+- which package folders were scanned
+- current load errors
+- loaded package ids, tool names, and settings status
+
+## Example Package
+
+A working example lives here:
+
+- [docs/examples/mcp-assist-tools/sample_tool/mcp_tool.json](examples/mcp-assist-tools/sample_tool/mcp_tool.json)
+- [docs/examples/mcp-assist-tools/sample_tool/tool.py](examples/mcp-assist-tools/sample_tool/tool.py)
+- [docs/examples/mcp-assist-tools/sample_tool/prompt.md](examples/mcp-assist-tools/sample_tool/prompt.md)
+
+## Troubleshooting
+
+### My custom tools do not appear
+
+Check:
+
+- **Custom Tools** is enabled in shared MCP server settings
+- the package lives under `<home-assistant-config>/mcp-assist-tools/<tool_id>/`
+- the folder name matches the manifest `id`
+- the manifest file is named `mcp_tool.json` and uses `schema_version: 1`
+- the tool names are properly prefixed with `<tool_id>_`
+- Home Assistant logs for `Failed to load external custom tool package`
+- the diagnostics endpoint or reload service output for package-specific load errors
+
+### My tool package loads but the model never uses it
+
+Check:
+
+- the tool description is clear and action-oriented
+- the package adds concise prompt guidance
+- the tool is narrow enough for the model to choose confidently
+- the tool name and description match the user intent it should handle
+
+### Can packages add profile-specific settings?
+
+Yes. Declare `get_settings_schema()` and use the shared/profile JSON settings paths described above.

--- a/docs/examples/mcp-assist-tools/sample_tool/mcp_tool.json
+++ b/docs/examples/mcp-assist-tools/sample_tool/mcp_tool.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "sample_tool",
+  "name": "Sample Tool",
+  "description": "Example external tool package for MCP Assist documentation.",
+  "version": "1.0.0",
+  "entrypoint": "tool:SampleTool",
+  "capabilities": [
+    "Provides a tiny example MCP tool and prompt guidance."
+  ],
+  "prompt_append_file": "prompt.md"
+}

--- a/docs/examples/mcp-assist-tools/sample_tool/prompt.md
+++ b/docs/examples/mcp-assist-tools/sample_tool/prompt.md
@@ -1,0 +1,1 @@
+Use `sample_tool_status` when the user asks for the sample system status exposed by this package.

--- a/docs/examples/mcp-assist-tools/sample_tool/tool.py
+++ b/docs/examples/mcp-assist-tools/sample_tool/tool.py
@@ -1,0 +1,62 @@
+"""Example external MCP Assist tool package."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.mcp_assist.custom_tool_api import MCPAssistExternalTool
+
+
+class SampleTool(MCPAssistExternalTool):
+    """Minimal example custom tool."""
+
+    def get_settings_schema(self) -> dict[str, Any]:
+        """Optional shared/profile settings schema for this package."""
+        return {
+            "type": "object",
+            "properties": {
+                "status_text": {
+                    "type": "string",
+                    "default": "Sample custom tool is working.",
+                }
+            },
+        }
+
+    def get_tool_definitions(self) -> list[dict[str, Any]]:
+        """Expose one namespaced example tool."""
+        return [
+            {
+                "name": "sample_tool_status",
+                "description": "Return the status exposed by the sample custom tool.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                },
+                "keywords": ["sample", "status", "custom"],
+                "example_queries": ["What's the sample tool status?"],
+                "preferred_when": "Use when the user asks about the sample package.",
+                "returns": "A short status summary.",
+            }
+        ]
+
+    async def handle_call(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return a normal MCP tool result."""
+        settings = self.get_settings()
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": str(
+                        settings.get("status_text")
+                        or "Sample custom tool is working."
+                    ),
+                }
+            ],
+            "isError": False,
+        }
+
+    def get_prompt_instructions(self) -> str:
+        """Add short guidance for the LLM."""
+        return "Use sample_tool_status for sample-status questions."


### PR DESCRIPTION
## Summary

This is PR 2 of the split-out sequence from #45. It focuses on the custom tool framework only and is intentionally independent from PR 1 (#48), which changes `agent.py` for agent/tool performance.

## What Changed

- Adds a stable `custom_tool_api.py` for manifest-based custom tool packages.
- Adds an external package loader with manifest validation, prompt appendices, settings overlays, safe shared-module loading, and diagnostics.
- Adds JSON-schema-style argument/settings validation helpers.
- Converts existing optional helpers into built-in package wrappers for search, read URL, calculator, and unit conversion.
- Adds minimal shared settings, service registration, MCP server hooks, and documentation/examples needed to load and reload custom tool packages.

## Explicitly Out Of Scope

- Agent tool performance changes from PR 1.
- Memory manager work.
- New MCP server tool domains.
- Full config-flow sections rework beyond the minimal flat toggles needed here.
- Test infrastructure and CI.
- Image analysis/generation tools.
- Music Assistant tools.
- Loose-end cleanup reserved for the final split PR.

## Conflict Check

PR 1 changes only `custom_components/mcp_assist/agent.py`; this PR does not touch that file. I also checked the two branches with `git merge-tree` and found no conflicts.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `python -m compileall -q custom_components/mcp_assist`
- `python -m json.tool custom_components/mcp_assist/strings.json`
- `python -m json.tool custom_components/mcp_assist/translations/en.json`
- `python -m json.tool` for each bundled/example `mcp_tool.json`