### PR TITLE
show historical data from newest to past

### DIFF
--- a/custom_components/mcp_assist/mcp_server.py
+++ b/custom_components/mcp_assist/mcp_server.py
@@ -1574,9 +1574,9 @@ class MCPServer:
                     }
                 ]
             }
-
-        # Reverse to get most recent first, apply limit
-        recent_states = list(reversed(entity_states[-limit:]))
+        
+        # Apply limit
+        recent_states = entity_states[:limit]
 
         # Build formatted text
         text_parts = [


### PR DESCRIPTION
In the modern version of HA, data was returned in reverse chronological order.
After fix: newest data is first.