### PR TITLE
update ddgs package

### DIFF
--- a/custom_components/mcp_assist/custom_tools/duckduckgo_search.py
+++ b/custom_components/mcp_assist/custom_tools/duckduckgo_search.py
@@ -1,7 +1,7 @@
 """DuckDuckGo Search custom tool for MCP Assist."""
 import logging
 from typing import Dict, Any, List
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class DuckDuckGoSearchTool:
         """Synchronous search wrapper for thread pool execution."""
         try:
             raw_results = DDGS().text(
-                keywords=query,
+                query=query,
                 max_results=count,
                 region="us-en",
                 safesearch="moderate",

--- a/custom_components/mcp_assist/manifest.json
+++ b/custom_components/mcp_assist/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mike-nott/mcp-assist/issues",
-  "requirements": ["aiohttp>=3.8.0", "pyyaml>=6.0", "duckduckgo-search>=6.0.0", "websockets>=12.0", "cryptography>=41.0.0"],
+  "requirements": ["aiohttp>=3.8.0", "pyyaml>=6.0", "ddgs>=6.0.0", "websockets>=12.0", "cryptography>=41.0.0"],
   "version": "0.16.2"
 }


### PR DESCRIPTION
Getting this in the home assistant logs and it seems to be falling back onto bing because of this:
2026-06-14 22:03:30.410 WARNING (SyncWorker_11) [py.warnings] /config/custom_components/mcp_assist/custom_tools/duckduckgo_search.py:88: RuntimeWarning: This package (`duckduckgo_search`) has been renamed to `ddgs`! Use `pip install ddgs` instead.

  raw_results = DDGS().text( 

Changing DDGS to ddgs resolves this issue.