### PR TITLE
Updated OpenClaw protocol version from 3 to 4

### DIFF
--- a/custom_components/mcp_assist/custom_tools/duckduckgo_search.py
+++ b/custom_components/mcp_assist/custom_tools/duckduckgo_search.py
@@ -1,7 +1,7 @@
 """DuckDuckGo Search custom tool for MCP Assist."""
 import logging
 from typing import Dict, Any, List
-from duckduckgo_search import DDGS
+from ddgs import DDGS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class DuckDuckGoSearchTool:
         """Synchronous search wrapper for thread pool execution."""
         try:
             raw_results = DDGS().text(
-                keywords=query,
+                query=query,
                 max_results=count,
                 region="us-en",
                 safesearch="moderate",

--- a/custom_components/mcp_assist/openclaw_client.py
+++ b/custom_components/mcp_assist/openclaw_client.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.storage import Store
 _LOGGER = logging.getLogger(__name__)
 
 # Protocol constants
-PROTOCOL_VERSION = 3
+PROTOCOL_VERSION = 4
 CLIENT_ID = "gateway-client"
 CLIENT_DISPLAY_NAME = "Home Assistant MCP Assist"
 CLIENT_VERSION = "1.0.0"


### PR DESCRIPTION
Edited `PROTOCOL_VERSION = 3` to `PROTOCOL_VERSION = 4` in `custom_components/mcp_assist/openclaw_client.py` to restore OpenClaw functionality. Seems stable and functional so far